### PR TITLE
Add enhanced worktree management features

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alex/gt
+module github.com/melonamin/gt
 
 go 1.23.0
 

--- a/main.go
+++ b/main.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
@@ -19,14 +22,26 @@ const (
 	defaultWorktreeDir = ".worktrees"
 	configFileName     = "config.json"
 	configDirName      = "gt"
+
+	// UI constants
+	maxCommitMsgLength   = 40
+	statusMessageTimeout = 3 * time.Second
+	refreshTimeout       = 2 * time.Second
+	minViewportHeight    = 5
+	viewportPadding      = 8 // Lines for header/footer
+	hashDisplayLength    = 7
+	branchDisplayWidth   = 20
+	ellipsis             = "..."
 )
 
+// Config holds user configuration loaded from ~/.config/gt/config.json.
 type Config struct {
 	WorktreeDir string `json:"worktree_dir,omitempty"`
 	Shell       string `json:"shell,omitempty"`
 	PostCreate  string `json:"post_create,omitempty"`
 }
 
+// Worktree represents a git worktree with its associated metadata.
 type Worktree struct {
 	Path       string
 	Branch     string
@@ -38,6 +53,7 @@ type Worktree struct {
 	Behind     int
 }
 
+// CommitInfo holds metadata about a git commit.
 type CommitInfo struct {
 	Hash    string
 	Message string
@@ -45,44 +61,74 @@ type CommitInfo struct {
 	Author  string
 }
 
-type model struct {
-	worktrees        []Worktree
-	filtered         []Worktree
-	cursor           int
-	scrollOffset     int
-	searchTerm       string
-	width            int
-	height           int
-	quitting         bool
-	inputMode        inputMode
-	inputValue       string
-	confirmDelete    bool
-	deleteTarget     *Worktree
-	repoPath         string
-	config           *Config
-	err              error
-	statusMessage    string
-	statusTimeout    time.Time
-	defaultBranch    string
-	previousWorktree string
-	actionCursor     int
-	actions          []action
-}
-
+// inputMode represents the current input state of the TUI.
 type inputMode int
 
 const (
-	modeNormal inputMode = iota
-	modeSearch
-	modeNewBranch
-	modeNewPath
-	modeActions
+	modeNormal    inputMode = iota // Browsing worktrees
+	modeSearch                     // Inline search filtering
+	modeNewBranch                  // Entering new branch name
+	modeNewPath                    // Entering custom worktree path
+	modeActions                    // Selecting from actions menu
 )
 
+// actionFn is the signature for worktree action handlers.
+type actionFn func(wt *Worktree, config *Config) error
+
+// action represents a menu action that can be performed on a worktree.
 type action struct {
-	key   string
-	label string
-	fn    func(wt *Worktree, config *Config) error
+	key          string
+	label        string
+	fn           actionFn
+	exitAfterRun bool // If false, return to TUI after action completes
+	darwinOnly   bool // If true, only available on macOS
+}
+
+// uiState holds the UI-related state for the TUI.
+type uiState struct {
+	cursor       int
+	scrollOffset int
+	width        int
+	height       int
+	inputMode    inputMode
+	inputValue   string
+}
+
+// worktreeState holds worktree-related data.
+type worktreeState struct {
+	worktrees        []Worktree
+	filtered         []Worktree
+	searchTerm       string
+	defaultBranch    string
+	previousWorktree string
+}
+
+// actionsState holds the state for the actions menu.
+type actionsState struct {
+	cursor  int
+	actions []action
+}
+
+// deleteState holds the state for delete confirmation.
+type deleteState struct {
+	confirming bool
+	target     *Worktree
+}
+
+// model is the Bubble Tea model for the TUI application.
+type model struct {
+	ui       uiState
+	wt       worktreeState
+	acts     actionsState
+	del      deleteState
+	repoPath string
+	config   *Config
+	err      error
+	status   struct {
+		message string
+		timeout time.Time
+	}
+	quitting bool
 }
 
 var (
@@ -129,6 +175,62 @@ var (
 	behindStyle = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("214"))
 )
+
+// printInfo prints a dimmed informational message to stdout.
+func printInfo(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	fmt.Printf("\n\033[2m%s\033[0m\n", msg)
+}
+
+// validateBranchName checks if the given name is valid for a git branch.
+func validateBranchName(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return errors.New("branch name cannot be empty")
+	}
+	if strings.HasPrefix(name, "-") {
+		return errors.New("branch name cannot start with '-'")
+	}
+	if strings.HasPrefix(name, ".") {
+		return errors.New("branch name cannot start with '.'")
+	}
+	if strings.HasSuffix(name, ".") {
+		return errors.New("branch name cannot end with '.'")
+	}
+	if strings.HasSuffix(name, ".lock") {
+		return errors.New("branch name cannot end with '.lock'")
+	}
+	if strings.Contains(name, "..") {
+		return errors.New("branch name cannot contain '..'")
+	}
+	if strings.Contains(name, " ") {
+		return errors.New("branch name cannot contain spaces")
+	}
+	if strings.Contains(name, "~") || strings.Contains(name, "^") ||
+		strings.Contains(name, ":") || strings.Contains(name, "?") ||
+		strings.Contains(name, "*") || strings.Contains(name, "[") ||
+		strings.Contains(name, "\\") {
+		return errors.New("branch name contains invalid characters")
+	}
+	// Shell metacharacters that could be dangerous in command execution
+	if strings.Contains(name, ";") || strings.Contains(name, "&") ||
+		strings.Contains(name, "|") || strings.Contains(name, "$") ||
+		strings.Contains(name, "`") || strings.Contains(name, "(") ||
+		strings.Contains(name, ")") || strings.Contains(name, "<") ||
+		strings.Contains(name, ">") {
+		return errors.New("branch name contains invalid characters")
+	}
+	return nil
+}
+
+// truncateString truncates a string to maxLen runes and adds ellipsis if needed.
+func truncateString(s string, maxLen int) string {
+	if utf8.RuneCountInString(s) <= maxLen {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:maxLen]) + ellipsis
+}
 
 func getConfigPath() string {
 	configHome, err := os.UserConfigDir()
@@ -182,6 +284,8 @@ func getCurrentRepoPath() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+// getAheadBehind returns the number of commits the branch is ahead/behind the default branch.
+// Returns (0, 0) if the branch is the default branch, or if any error occurs during git operations.
 func getAheadBehind(worktreePath, branch, defaultBranch string) (ahead, behind int) {
 	if branch == "" || branch == defaultBranch {
 		return 0, 0
@@ -192,16 +296,27 @@ func getAheadBehind(worktreePath, branch, defaultBranch string) (ahead, behind i
 	cmd.Dir = worktreePath
 	output, err := cmd.Output()
 	if err != nil {
+		// Git command failed (e.g., branch doesn't exist in remote, or not a valid ref)
+		// Silently return 0,0 as this is a non-critical display feature
 		return 0, 0
 	}
 
 	parts := strings.Fields(strings.TrimSpace(string(output)))
-	if len(parts) == 2 {
-		behind, _ = strconv.Atoi(parts[0])
-		ahead, _ = strconv.Atoi(parts[1])
+	if len(parts) != 2 {
+		// Unexpected output format
+		return 0, 0
 	}
 
-	return ahead, behind
+	behindVal, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0
+	}
+	aheadVal, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0
+	}
+
+	return aheadVal, behindVal
 }
 
 func getWorktrees(repoPath string) ([]Worktree, error) {
@@ -263,7 +378,11 @@ func getWorktrees(repoPath string) ([]Worktree, error) {
 		if err == nil && len(output) > 0 {
 			parts := strings.Split(string(output), "|")
 			if len(parts) >= 4 {
-				worktrees[i].LastCommit.Hash = parts[0][:7]
+				hash := parts[0]
+				if len(hash) > hashDisplayLength {
+					hash = hash[:hashDisplayLength]
+				}
+				worktrees[i].LastCommit.Hash = hash
 				worktrees[i].LastCommit.Message = parts[1]
 				if t, err := time.Parse("2006-01-02 15:04:05 -0700", parts[2]); err == nil {
 					worktrees[i].LastCommit.Date = t
@@ -330,11 +449,13 @@ func formatRelativeTime(t time.Time) string {
 	}
 }
 
+// getActions returns the list of available worktree actions, filtered by platform.
 func getActions() []action {
-	return []action{
+	allActions := []action{
 		{
-			key:   "e",
-			label: "Open in editor ($EDITOR)",
+			key:          "e",
+			label:        "Open in editor ($EDITOR)",
+			exitAfterRun: true,
 			fn: func(wt *Worktree, config *Config) error {
 				editor := os.Getenv("EDITOR")
 				if editor == "" {
@@ -348,16 +469,21 @@ func getActions() []action {
 			},
 		},
 		{
-			key:   "c",
-			label: "Open in VS Code",
+			key:          "c",
+			label:        "Open in VS Code",
+			exitAfterRun: true,
 			fn: func(wt *Worktree, config *Config) error {
+				if _, err := exec.LookPath("code"); err != nil {
+					return errors.New("VS Code not found (command 'code' not in PATH)")
+				}
 				cmd := exec.Command("code", wt.Path)
 				return cmd.Run()
 			},
 		},
 		{
-			key:   "t",
-			label: "Open terminal here",
+			key:          "t",
+			label:        "Open terminal here",
+			exitAfterRun: true,
 			fn: func(wt *Worktree, config *Config) error {
 				shell := getShell(config)
 				cmd := exec.Command(shell)
@@ -369,16 +495,20 @@ func getActions() []action {
 			},
 		},
 		{
-			key:   "f",
-			label: "Open in Finder",
+			key:          "f",
+			label:        "Open in Finder",
+			exitAfterRun: false, // Can stay in TUI
+			darwinOnly:   true,
 			fn: func(wt *Worktree, config *Config) error {
 				cmd := exec.Command("open", wt.Path)
 				return cmd.Run()
 			},
 		},
 		{
-			key:   "p",
-			label: "Copy path to clipboard",
+			key:          "p",
+			label:        "Copy path to clipboard",
+			exitAfterRun: false, // Stay in TUI after copy
+			darwinOnly:   true,
 			fn: func(wt *Worktree, config *Config) error {
 				cmd := exec.Command("pbcopy")
 				cmd.Stdin = strings.NewReader(wt.Path)
@@ -386,6 +516,19 @@ func getActions() []action {
 			},
 		},
 	}
+
+	// Filter actions by platform
+	if runtime.GOOS == "darwin" {
+		return allActions
+	}
+
+	var filtered []action
+	for _, a := range allActions {
+		if !a.darwinOnly {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
 }
 
 func initialModel() model {
@@ -407,7 +550,7 @@ func initialModel() model {
 	// Get default branch for ^ shortcut
 	defaultBranch := getDefaultBranch(repoPath)
 
-	// Find current worktree path for tracking previous
+	// Find current worktree path for tracking previous (session-only)
 	var currentPath string
 	for _, wt := range worktrees {
 		if wt.IsCurrent {
@@ -416,17 +559,20 @@ func initialModel() model {
 		}
 	}
 
-	m := model{
-		worktrees:        worktrees,
-		filtered:         worktrees,
-		repoPath:         repoPath,
-		config:           config,
-		defaultBranch:    defaultBranch,
-		previousWorktree: currentPath,
-		actions:          getActions(),
+	return model{
+		ui: uiState{},
+		wt: worktreeState{
+			worktrees:        worktrees,
+			filtered:         worktrees,
+			defaultBranch:    defaultBranch,
+			previousWorktree: currentPath,
+		},
+		acts: actionsState{
+			actions: getActions(),
+		},
+		repoPath: repoPath,
+		config:   config,
 	}
-
-	return m
 }
 
 func (m model) Init() tea.Cmd {
@@ -441,291 +587,339 @@ func tickCmd() tea.Cmd {
 	})
 }
 
+// setStatus sets a status message that will be displayed temporarily.
+func (m *model) setStatus(msg string, timeout time.Duration) {
+	m.status.message = msg
+	m.status.timeout = time.Now().Add(timeout)
+}
+
+// refreshWorktrees reloads the worktree list from git.
+func (m *model) refreshWorktrees() {
+	worktrees, err := getWorktrees(m.repoPath)
+	if err != nil {
+		m.setStatus(fmt.Sprintf("Refresh failed: %v", err), statusMessageTimeout)
+		return
+	}
+	m.wt.worktrees = worktrees
+	m.wt.filtered = filterWorktrees(worktrees, m.wt.searchTerm)
+}
+
+// clampScroll adjusts scroll offset to keep the cursor visible within the viewport.
+func (m *model) clampScroll() {
+	viewportHeight := m.ui.height - viewportPadding
+	if viewportHeight < minViewportHeight {
+		viewportHeight = minViewportHeight
+	}
+
+	if m.ui.cursor >= m.ui.scrollOffset+viewportHeight {
+		m.ui.scrollOffset = m.ui.cursor - viewportHeight + 1
+	} else if m.ui.cursor < m.ui.scrollOffset {
+		m.ui.scrollOffset = m.ui.cursor
+	}
+}
+
+// handleDeleteConfirm handles key input during delete confirmation.
+func (m model) handleDeleteConfirm(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		if m.del.target != nil {
+			if err := deleteWorktree(m.repoPath, m.del.target.Path); err != nil {
+				m.err = err
+			} else {
+				m.setStatus(fmt.Sprintf("Deleted worktree: %s", m.del.target.Branch), statusMessageTimeout)
+				m.refreshWorktrees()
+			}
+		}
+		m.del.confirming = false
+		m.del.target = nil
+		return m, tickCmd()
+	case "n", "N", "esc", "ctrl+c":
+		m.del.confirming = false
+		m.del.target = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+// handleSearchMode handles key input during search mode.
+func (m model) handleSearchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.ui.inputMode = modeNormal
+		m.wt.searchTerm = ""
+		m.wt.filtered = m.wt.worktrees
+		return m, nil
+	case "enter":
+		m.ui.inputMode = modeNormal
+		return m, nil
+	case "backspace":
+		if len(m.wt.searchTerm) > 0 {
+			m.wt.searchTerm = m.wt.searchTerm[:len(m.wt.searchTerm)-1]
+			m.wt.filtered = filterWorktrees(m.wt.worktrees, m.wt.searchTerm)
+		}
+		return m, nil
+	default:
+		if len(msg.String()) == 1 {
+			m.wt.searchTerm += msg.String()
+			m.wt.filtered = filterWorktrees(m.wt.worktrees, m.wt.searchTerm)
+		}
+		return m, nil
+	}
+}
+
+// handleNewBranchMode handles key input during new branch creation.
+func (m model) handleNewBranchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c":
+		m.ui.inputMode = modeNormal
+		m.ui.inputValue = ""
+		return m, nil
+	case "enter":
+		if m.ui.inputValue != "" {
+			if err := validateBranchName(m.ui.inputValue); err != nil {
+				m.err = err
+			} else if err := createWorktree(m.repoPath, m.ui.inputValue, m.config); err != nil {
+				m.err = err
+			} else {
+				m.setStatus(fmt.Sprintf("Created worktree: %s", m.ui.inputValue), statusMessageTimeout)
+				m.refreshWorktrees()
+			}
+		}
+		m.ui.inputMode = modeNormal
+		m.ui.inputValue = ""
+		return m, tickCmd()
+	case "backspace":
+		if len(m.ui.inputValue) > 0 {
+			m.ui.inputValue = m.ui.inputValue[:len(m.ui.inputValue)-1]
+		}
+		return m, nil
+	default:
+		if len(msg.String()) == 1 || msg.String() == "/" || msg.String() == "-" {
+			m.ui.inputValue += msg.String()
+		}
+		return m, nil
+	}
+}
+
+// runAction executes an action and handles whether to exit or stay in TUI.
+func (m model) runAction(action action, wt *Worktree) (tea.Model, tea.Cmd) {
+	m.ui.inputMode = modeNormal
+
+	if action.exitAfterRun {
+		m.quitting = true
+		printInfo("Running: %s", action.label)
+		if err := action.fn(wt, m.config); err != nil {
+			fmt.Fprintf(os.Stderr, "Action failed: %v\n", err)
+		}
+		return m, tea.Quit
+	}
+
+	// Non-exiting action: run and show status
+	if err := action.fn(wt, m.config); err != nil {
+		m.setStatus(fmt.Sprintf("Action failed: %v", err), statusMessageTimeout)
+	} else {
+		m.setStatus(fmt.Sprintf("%s completed", action.label), refreshTimeout)
+	}
+	return m, tickCmd()
+}
+
+// handleActionsMode handles key input during action selection.
+func (m model) handleActionsMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c", "q":
+		m.ui.inputMode = modeNormal
+		return m, nil
+	case "up", "k":
+		if m.acts.cursor > 0 {
+			m.acts.cursor--
+		}
+		return m, nil
+	case "down", "j":
+		if m.acts.cursor < len(m.acts.actions)-1 {
+			m.acts.cursor++
+		}
+		return m, nil
+	case "enter":
+		if m.ui.cursor < len(m.wt.filtered) && m.acts.cursor < len(m.acts.actions) {
+			wt := m.wt.filtered[m.ui.cursor]
+			action := m.acts.actions[m.acts.cursor]
+			return m.runAction(action, &wt)
+		}
+		return m, nil
+	default:
+		// Check for action shortcut keys
+		for _, action := range m.acts.actions {
+			if msg.String() == action.key {
+				if m.ui.cursor < len(m.wt.filtered) {
+					wt := m.wt.filtered[m.ui.cursor]
+					return m.runAction(action, &wt)
+				}
+			}
+		}
+		return m, nil
+	}
+}
+
+// handleNormalMode handles key input during normal browsing mode.
+func (m model) handleNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		m.quitting = true
+		return m, tea.Quit
+
+	case "up", "k":
+		if m.ui.cursor > 0 {
+			m.ui.cursor--
+			m.clampScroll()
+		}
+		return m, nil
+
+	case "down", "j":
+		if m.ui.cursor < len(m.wt.filtered)-1 {
+			m.ui.cursor++
+			m.clampScroll()
+		}
+		return m, nil
+
+	case "/":
+		m.ui.inputMode = modeSearch
+		m.wt.searchTerm = ""
+		return m, nil
+
+	case "n":
+		m.ui.inputMode = modeNewBranch
+		m.ui.inputValue = ""
+		return m, nil
+
+	case "d":
+		if m.ui.cursor < len(m.wt.filtered) {
+			wt := &m.wt.filtered[m.ui.cursor]
+			if strings.HasSuffix(m.repoPath, wt.Path) {
+				m.err = fmt.Errorf("cannot delete main worktree")
+				return m, nil
+			}
+			m.del.confirming = true
+			m.del.target = wt
+		}
+		return m, nil
+
+	case "r":
+		m.refreshWorktrees()
+		m.setStatus("Refreshed", refreshTimeout)
+		return m, tickCmd()
+
+	case "^":
+		for i, wt := range m.wt.filtered {
+			if wt.Branch == m.wt.defaultBranch {
+				m.ui.cursor = i
+				m.clampScroll()
+				m.setStatus(fmt.Sprintf("Jumped to default branch: %s", m.wt.defaultBranch), refreshTimeout)
+				break
+			}
+		}
+		return m, tickCmd()
+
+	case "-":
+		if m.wt.previousWorktree != "" {
+			for i, wt := range m.wt.filtered {
+				if wt.Path == m.wt.previousWorktree {
+					m.ui.cursor = i
+					m.clampScroll()
+					m.setStatus("Jumped to previous worktree (session)", refreshTimeout)
+					break
+				}
+			}
+		}
+		return m, tickCmd()
+
+	case "@":
+		for i, wt := range m.wt.filtered {
+			if wt.IsCurrent {
+				m.ui.cursor = i
+				m.clampScroll()
+				m.setStatus("Jumped to current worktree", refreshTimeout)
+				break
+			}
+		}
+		return m, tickCmd()
+
+	case "a":
+		if m.ui.cursor < len(m.wt.filtered) {
+			m.ui.inputMode = modeActions
+			m.acts.cursor = 0
+		}
+		return m, nil
+
+	case "enter":
+		if m.ui.cursor < len(m.wt.filtered) {
+			wt := m.wt.filtered[m.ui.cursor]
+
+			// Track previous worktree before switching (session-only)
+			for _, w := range m.wt.worktrees {
+				if w.IsCurrent {
+					m.wt.previousWorktree = w.Path
+					break
+				}
+			}
+
+			m.quitting = true
+			printInfo("Switching to %s...", wt.Path)
+
+			if err := os.Chdir(wt.Path); err != nil {
+				m.err = err
+				return m, nil
+			}
+
+			shell := getShell(m.config)
+			cmd := exec.Command(shell)
+			cmd.Stdin = os.Stdin
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+			cmd.Dir = wt.Path
+
+			return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
+				if err != nil {
+					return err
+				}
+				return tea.Quit()
+			})
+		}
+		return m, nil
+	}
+	return m, nil
+}
+
 func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
-		m.width = msg.Width
-		m.height = msg.Height
+		m.ui.width = msg.Width
+		m.ui.height = msg.Height
 		return m, nil
 
 	case tickMsg:
-		if !m.statusTimeout.IsZero() && time.Now().After(m.statusTimeout) {
-			m.statusMessage = ""
-			m.statusTimeout = time.Time{}
+		if !m.status.timeout.IsZero() && time.Now().After(m.status.timeout) {
+			m.status.message = ""
+			m.status.timeout = time.Time{}
 		}
 		return m, tickCmd()
 
 	case tea.KeyMsg:
-		if m.confirmDelete {
-			switch msg.String() {
-			case "y", "Y":
-				if m.deleteTarget != nil {
-					if err := deleteWorktree(m.repoPath, m.deleteTarget.Path); err != nil {
-						m.err = err
-					} else {
-						m.statusMessage = fmt.Sprintf("Deleted worktree: %s", m.deleteTarget.Branch)
-						m.statusTimeout = time.Now().Add(3 * time.Second)
-						// Refresh worktrees
-						if worktrees, err := getWorktrees(m.repoPath); err == nil {
-							m.worktrees = worktrees
-							m.filtered = filterWorktrees(worktrees, m.searchTerm)
-						}
-					}
-				}
-				m.confirmDelete = false
-				m.deleteTarget = nil
-				return m, tickCmd()
-			case "n", "N", "esc", "ctrl+c":
-				m.confirmDelete = false
-				m.deleteTarget = nil
-				return m, nil
-			}
-			return m, nil
+		// Clear any previous operational error on keypress
+		m.err = nil
+
+		if m.del.confirming {
+			return m.handleDeleteConfirm(msg)
 		}
 
-		switch m.inputMode {
+		switch m.ui.inputMode {
 		case modeSearch:
-			switch msg.String() {
-			case "esc", "ctrl+c":
-				m.inputMode = modeNormal
-				m.searchTerm = ""
-				m.filtered = m.worktrees
-				return m, nil
-			case "enter":
-				m.inputMode = modeNormal
-				return m, nil
-			case "backspace":
-				if len(m.searchTerm) > 0 {
-					m.searchTerm = m.searchTerm[:len(m.searchTerm)-1]
-					m.filtered = filterWorktrees(m.worktrees, m.searchTerm)
-				}
-				return m, nil
-			default:
-				if len(msg.String()) == 1 {
-					m.searchTerm += msg.String()
-					m.filtered = filterWorktrees(m.worktrees, m.searchTerm)
-				}
-				return m, nil
-			}
-
+			return m.handleSearchMode(msg)
 		case modeNewBranch:
-			switch msg.String() {
-			case "esc", "ctrl+c":
-				m.inputMode = modeNormal
-				m.inputValue = ""
-				return m, nil
-			case "enter":
-				if m.inputValue != "" {
-					if err := createWorktree(m.repoPath, m.inputValue, m.config); err != nil {
-						m.err = err
-					} else {
-						m.statusMessage = fmt.Sprintf("Created worktree: %s", m.inputValue)
-						m.statusTimeout = time.Now().Add(3 * time.Second)
-						// Refresh worktrees
-						if worktrees, err := getWorktrees(m.repoPath); err == nil {
-							m.worktrees = worktrees
-							m.filtered = filterWorktrees(worktrees, m.searchTerm)
-						}
-					}
-				}
-				m.inputMode = modeNormal
-				m.inputValue = ""
-				return m, tickCmd()
-			case "backspace":
-				if len(m.inputValue) > 0 {
-					m.inputValue = m.inputValue[:len(m.inputValue)-1]
-				}
-				return m, nil
-			default:
-				if len(msg.String()) == 1 || msg.String() == "/" || msg.String() == "-" {
-					m.inputValue += msg.String()
-				}
-				return m, nil
-			}
-
+			return m.handleNewBranchMode(msg)
 		case modeActions:
-			switch msg.String() {
-			case "esc", "ctrl+c", "q":
-				m.inputMode = modeNormal
-				return m, nil
-			case "up", "k":
-				if m.actionCursor > 0 {
-					m.actionCursor--
-				}
-				return m, nil
-			case "down", "j":
-				if m.actionCursor < len(m.actions)-1 {
-					m.actionCursor++
-				}
-				return m, nil
-			case "enter":
-				if m.cursor < len(m.filtered) && m.actionCursor < len(m.actions) {
-					wt := m.filtered[m.cursor]
-					action := m.actions[m.actionCursor]
-					m.inputMode = modeNormal
-					m.quitting = true
-					fmt.Printf("\n\033[2mRunning: %s\033[0m\n", action.label)
-					if err := action.fn(&wt, m.config); err != nil {
-						fmt.Fprintf(os.Stderr, "Action failed: %v\n", err)
-					}
-					return m, tea.Quit
-				}
-				return m, nil
-			default:
-				// Check for action shortcut keys
-				for _, action := range m.actions {
-					if msg.String() == action.key {
-						if m.cursor < len(m.filtered) {
-							wt := m.filtered[m.cursor]
-							m.inputMode = modeNormal
-							m.quitting = true
-							fmt.Printf("\n\033[2mRunning: %s\033[0m\n", action.label)
-							if err := action.fn(&wt, m.config); err != nil {
-								fmt.Fprintf(os.Stderr, "Action failed: %v\n", err)
-							}
-							return m, tea.Quit
-						}
-					}
-				}
-				return m, nil
-			}
-
-		default: // modeNormal
-			switch msg.String() {
-			case "q", "ctrl+c":
-				m.quitting = true
-				return m, tea.Quit
-
-			case "up", "k":
-				if m.cursor > 0 {
-					m.cursor--
-				}
-				return m, nil
-
-			case "down", "j":
-				if m.cursor < len(m.filtered)-1 {
-					m.cursor++
-				}
-				return m, nil
-
-			case "/":
-				m.inputMode = modeSearch
-				m.searchTerm = ""
-				return m, nil
-
-			case "n":
-				m.inputMode = modeNewBranch
-				m.inputValue = ""
-				return m, nil
-
-			case "d":
-				if m.cursor < len(m.filtered) {
-					wt := &m.filtered[m.cursor]
-					if strings.HasSuffix(m.repoPath, wt.Path) {
-						m.err = fmt.Errorf("cannot delete main worktree")
-						return m, nil
-					}
-					m.confirmDelete = true
-					m.deleteTarget = wt
-				}
-				return m, nil
-
-			case "r":
-				// Refresh worktrees
-				if worktrees, err := getWorktrees(m.repoPath); err == nil {
-					m.worktrees = worktrees
-					m.filtered = filterWorktrees(worktrees, m.searchTerm)
-					m.statusMessage = "Refreshed"
-					m.statusTimeout = time.Now().Add(2 * time.Second)
-				}
-				return m, tickCmd()
-
-			case "^":
-				// Jump to default branch worktree
-				for i, wt := range m.filtered {
-					if wt.Branch == m.defaultBranch {
-						m.cursor = i
-						m.statusMessage = fmt.Sprintf("Jumped to default branch: %s", m.defaultBranch)
-						m.statusTimeout = time.Now().Add(2 * time.Second)
-						break
-					}
-				}
-				return m, tickCmd()
-
-			case "-":
-				// Jump to previous worktree
-				if m.previousWorktree != "" {
-					for i, wt := range m.filtered {
-						if wt.Path == m.previousWorktree {
-							m.cursor = i
-							m.statusMessage = "Jumped to previous worktree"
-							m.statusTimeout = time.Now().Add(2 * time.Second)
-							break
-						}
-					}
-				}
-				return m, tickCmd()
-
-			case "@":
-				// Jump to current worktree
-				for i, wt := range m.filtered {
-					if wt.IsCurrent {
-						m.cursor = i
-						m.statusMessage = "Jumped to current worktree"
-						m.statusTimeout = time.Now().Add(2 * time.Second)
-						break
-					}
-				}
-				return m, tickCmd()
-
-			case "a":
-				// Open actions menu
-				if m.cursor < len(m.filtered) {
-					m.inputMode = modeActions
-					m.actionCursor = 0
-				}
-				return m, nil
-
-			case "enter":
-				if m.cursor < len(m.filtered) {
-					wt := m.filtered[m.cursor]
-
-					// Track previous worktree before switching
-					for _, w := range m.worktrees {
-						if w.IsCurrent {
-							m.previousWorktree = w.Path
-							break
-						}
-					}
-
-					// Exit the TUI and switch to the worktree
-					m.quitting = true
-					fmt.Printf("\n\033[2mSwitching to %s...\033[0m\n", wt.Path)
-					
-					// Change to the worktree directory
-					if err := os.Chdir(wt.Path); err != nil {
-						m.err = err
-						return m, nil
-					}
-					
-					// Start a new shell in the worktree directory
-					shell := getShell(m.config)
-					cmd := exec.Command(shell)
-					cmd.Stdin = os.Stdin
-					cmd.Stdout = os.Stdout
-					cmd.Stderr = os.Stderr
-					cmd.Dir = wt.Path
-					
-					// Execute the shell after quitting the TUI
-					return m, tea.ExecProcess(cmd, func(err error) tea.Msg {
-						if err != nil {
-							return err
-						}
-						return tea.Quit()
-					})
-				}
-				return m, nil
-			}
+			return m.handleActionsMode(msg)
+		default:
+			return m.handleNormalMode(msg)
 		}
 	}
 
@@ -924,22 +1118,22 @@ func (m model) View() string {
 	s.WriteString(titleStyle.Render(title) + "\n")
 
 	// Search or input
-	switch m.inputMode {
+	switch m.ui.inputMode {
 	case modeSearch:
-		s.WriteString(searchStyle.Render("Search: ") + m.searchTerm + "█\n\n")
+		s.WriteString(searchStyle.Render("Search: ") + m.wt.searchTerm + "█\n\n")
 	case modeNewBranch:
-		s.WriteString(searchStyle.Render("New branch name: ") + m.inputValue + "█\n\n")
+		s.WriteString(searchStyle.Render("New branch name: ") + m.ui.inputValue + "█\n\n")
 	case modeActions:
-		if m.cursor < len(m.filtered) {
-			wt := m.filtered[m.cursor]
+		if m.ui.cursor < len(m.wt.filtered) {
+			wt := m.wt.filtered[m.ui.cursor]
 			s.WriteString(searchStyle.Render(fmt.Sprintf("Actions for %s:\n", wt.Branch)))
-			for i, action := range m.actions {
+			for i, action := range m.acts.actions {
 				cursor := "  "
-				if i == m.actionCursor {
+				if i == m.acts.cursor {
 					cursor = "▸ "
 				}
 				line := fmt.Sprintf("%s[%s] %s", cursor, action.key, action.label)
-				if i == m.actionCursor {
+				if i == m.acts.cursor {
 					s.WriteString(selectedStyle.Render(line) + "\n")
 				} else {
 					s.WriteString(line + "\n")
@@ -949,41 +1143,34 @@ func (m model) View() string {
 		}
 		return s.String()
 	default:
-		if m.searchTerm != "" {
-			s.WriteString(searchStyle.Render("Search: ") + dimStyle.Render(m.searchTerm) + "\n\n")
+		if m.wt.searchTerm != "" {
+			s.WriteString(searchStyle.Render("Search: ") + dimStyle.Render(m.wt.searchTerm) + "\n\n")
 		} else {
 			s.WriteString("\n")
 		}
 	}
 
 	// Confirmation dialog
-	if m.confirmDelete && m.deleteTarget != nil {
-		s.WriteString(errorStyle.Render(fmt.Sprintf("\nDelete worktree '%s'? [y/N] ", m.deleteTarget.Branch)))
+	if m.del.confirming && m.del.target != nil {
+		s.WriteString(errorStyle.Render(fmt.Sprintf("\nDelete worktree '%s'? [y/N] ", m.del.target.Branch)))
 		return s.String()
 	}
 
 	// Worktree list
-	if len(m.filtered) == 0 {
+	if len(m.wt.filtered) == 0 {
 		s.WriteString(dimStyle.Render("  No worktrees found\n"))
 	} else {
-		viewportHeight := m.height - 8 // Account for header and footer
-		if viewportHeight < 5 {
-			viewportHeight = 5
+		viewportHeight := m.ui.height - viewportPadding
+		if viewportHeight < minViewportHeight {
+			viewportHeight = minViewportHeight
 		}
 
-		// Adjust scroll offset
-		if m.cursor >= m.scrollOffset+viewportHeight {
-			m.scrollOffset = m.cursor - viewportHeight + 1
-		} else if m.cursor < m.scrollOffset {
-			m.scrollOffset = m.cursor
-		}
+		for i := m.ui.scrollOffset; i < len(m.wt.filtered) && i < m.ui.scrollOffset+viewportHeight; i++ {
+			wt := m.wt.filtered[i]
 
-		for i := m.scrollOffset; i < len(m.filtered) && i < m.scrollOffset+viewportHeight; i++ {
-			wt := m.filtered[i]
-			
 			// Cursor indicator
 			cursor := "  "
-			if i == m.cursor {
+			if i == m.ui.cursor {
 				cursor = "▸ "
 			}
 
@@ -1018,23 +1205,20 @@ func (m model) View() string {
 			}
 
 			// Commit info
-			commitMsg := wt.LastCommit.Message
-			if len(commitMsg) > 40 {
-				commitMsg = commitMsg[:40] + "..."
-			}
-
+			commitMsg := truncateString(wt.LastCommit.Message, maxCommitMsgLength)
 			relTime := formatRelativeTime(wt.LastCommit.Date)
 
 			// Format line
-			line := fmt.Sprintf("%s%-20s %s%s  %s",
+			line := fmt.Sprintf("%s%-*s %s%s  %s",
 				cursor,
+				branchDisplayWidth,
 				branch,
 				status,
 				aheadBehind,
 				dimStyle.Render(fmt.Sprintf("%s (%s)", commitMsg, relTime)),
 			)
 
-			if i == m.cursor {
+			if i == m.ui.cursor {
 				s.WriteString(selectedStyle.Render(line) + "\n")
 			} else {
 				s.WriteString(line + "\n")
@@ -1042,14 +1226,19 @@ func (m model) View() string {
 		}
 	}
 
+	// Error message (operational errors, not fatal)
+	if m.err != nil {
+		s.WriteString("\n" + errorStyle.Render(fmt.Sprintf("Error: %v", m.err)) + "\n")
+	}
+
 	// Status message
-	if m.statusMessage != "" {
-		s.WriteString("\n" + successStyle.Render(m.statusMessage) + "\n")
+	if m.status.message != "" {
+		s.WriteString("\n" + successStyle.Render(m.status.message) + "\n")
 	}
 
 	// Help
 	s.WriteString("\n")
-	if m.inputMode == modeNormal {
+	if m.ui.inputMode == modeNormal {
 		help := "[n]ew  [d]elete  [a]ctions  [enter] switch  [/] search  [r]efresh  [^] default  [-] prev  [@] current  [q]uit"
 		s.WriteString(helpStyle.Render(help))
 	} else {


### PR DESCRIPTION
## Summary

- Add worktree creation with custom branch names and optional custom paths
- Add contextual actions menu (a key) with macOS-specific integrations (Finder, Terminal, IDE)
- Add navigation shortcuts: `^` jump to default branch, `-` jump to previous worktree, `@` jump to current
- Add inline search/filter mode for worktrees
- Add auto-refresh on window focus and periodic background refresh
- Fix security and UI issues: shell metacharacter validation, scroll offset persistence, Unicode truncation, error display

## Test plan

- [ ] Run `gt` and verify worktree list displays correctly
- [ ] Test creating a new worktree with `n` key
- [ ] Test actions menu with `a` key on a worktree
- [ ] Test navigation: `^` (default branch), `-` (previous), `@` (current)
- [ ] Test search with `/` key
- [ ] Verify branch name validation rejects shell metacharacters (`;`, `&`, `|`, etc.)