### PR TITLE
Fix worktree excludes handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Use `.git/info/exclude` for worktree ignore entries instead of editing `.gitignore`
+- Fail worktree creation when the worktree directory contains tracked files
+
 ## [0.1.0] - 2025-01-29
 
 ### 🎉 Initial Release

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ever find yourself juggling multiple feature branches, hotfixes, and experiments
 Instantly manage all your Git worktrees with:
 - **Interactive TUI** - See all worktrees at a glance
 - **Instant creation** - `gt feature-x` creates and switches in one command
-- **Smart organization** - Keeps worktrees in `.worktrees/` (auto-added to `.gitignore`)
+- **Smart organization** - Keeps worktrees in `.worktrees/` (auto-added to `.git/info/exclude`)
 - **Zero config** - Single binary, works out of the box
 
 ## Installation
@@ -124,7 +124,7 @@ Worktrees are stored in `.worktrees/` within your repo:
 ```
 my-project/
 ├── .git/
-├── .worktrees/       # All worktrees here (auto-added to .gitignore)
+├── .worktrees/       # All worktrees here (auto-added to .git/info/exclude)
 │   ├── feature-auth/
 │   ├── fix-bug/
 │   └── experiment/
@@ -205,7 +205,7 @@ Git worktrees let you have multiple working directories for the same repository.
 1. Organizing them in one place
 2. Providing instant creation/switching
 3. Showing status at a glance
-4. Auto-managing `.gitignore`
+4. Auto-managing `.git/info/exclude`
 
 ## Comparison with Alternatives
 
@@ -224,7 +224,7 @@ Git worktrees let you have multiple working directories for the same repository.
 A: `gt` is to `git worktree` what `tig` is to `git log`. It makes the powerful feature actually pleasant to use.
 
 **Q: Where are my worktrees stored?**
-A: By default in `.worktrees/` within your repo. This is configurable and automatically added to `.gitignore`.
+A: By default in `.worktrees/` within your repo. This is configurable and automatically added to `.git/info/exclude`.
 
 **Q: Can I use my existing worktrees?**
 A: Yes! `gt` shows all worktrees, regardless of where they were created.

--- a/main.go
+++ b/main.go
@@ -1016,16 +1016,39 @@ func getShell(config *Config) string {
 	return "/bin/bash"
 }
 
-func ensureGitignoreEntry(repoPath, entry string) error {
-	gitignorePath := filepath.Join(repoPath, ".gitignore")
+func gitExcludePath(repoPath string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve git dir: %w", err)
+	}
+
+	gitDir := strings.TrimSpace(string(output))
+	if gitDir == "" {
+		return "", fmt.Errorf("git dir not found")
+	}
+
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(repoPath, gitDir)
+	}
+
+	return filepath.Join(gitDir, "info", "exclude"), nil
+}
+
+func ensureGitExcludeEntry(repoPath, entry string) error {
+	excludePath, err := gitExcludePath(repoPath)
+	if err != nil {
+		return err
+	}
 
 	// Ensure entry ends with / if it's a directory
 	if !strings.HasSuffix(entry, "/") {
 		entry = entry + "/"
 	}
 
-	// Read existing .gitignore content
-	content, err := os.ReadFile(gitignorePath)
+	// Read existing exclude file content
+	content, err := os.ReadFile(excludePath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -1040,7 +1063,7 @@ func ensureGitignoreEntry(repoPath, entry string) error {
 		}
 	}
 
-	// Add entry to .gitignore
+	// Add entry to git excludes
 	newContent := string(content)
 	if len(content) > 0 && !strings.HasSuffix(newContent, "\n") {
 		newContent += "\n"
@@ -1063,7 +1086,26 @@ func ensureGitignoreEntry(repoPath, entry string) error {
 
 	newContent += entry + "\n"
 
-	return os.WriteFile(gitignorePath, []byte(newContent), 0644)
+	return os.WriteFile(excludePath, []byte(newContent), 0644)
+}
+
+func ensureNoTrackedFiles(repoPath, relPath string) error {
+	relPath = strings.TrimSuffix(filepath.ToSlash(relPath), "/")
+	if relPath == "" {
+		return nil
+	}
+
+	cmd := exec.Command("git", "ls-files", "-z", "--", relPath)
+	cmd.Dir = repoPath
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("failed to check tracked files under %s: %w", relPath, err)
+	}
+	if len(output) > 0 {
+		return fmt.Errorf("worktree directory %q contains tracked files; use a different worktree_dir", relPath)
+	}
+
+	return nil
 }
 
 func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, config *Config) error {
@@ -1083,14 +1125,17 @@ func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, confi
 		return err
 	}
 
-	// Add worktree directory to .gitignore if it's within the repo
+	// Add worktree directory to git excludes if it's within the repo
 	if strings.HasPrefix(worktreeDir, repoPath) {
 		relPath, _ := filepath.Rel(repoPath, worktreeDir)
 		if relPath != "" && !strings.HasPrefix(relPath, "..") {
-			if err := ensureGitignoreEntry(repoPath, relPath); err != nil {
-				// Don't fail the worktree creation if we can't update .gitignore
+			if err := ensureNoTrackedFiles(repoPath, relPath); err != nil {
+				return err
+			}
+			if err := ensureGitExcludeEntry(repoPath, relPath); err != nil {
+				// Don't fail the worktree creation if we can't update git excludes
 				// Just continue with a warning
-				fmt.Fprintf(os.Stderr, "Warning: Could not update .gitignore: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: Could not update git excludes: %v\n", err)
 			}
 		}
 	}
@@ -1132,14 +1177,17 @@ func createWorktree(repoPath, branch string, config *Config) error {
 		return err
 	}
 
-	// Add worktree directory to .gitignore if it's within the repo
+	// Add worktree directory to git excludes if it's within the repo
 	if strings.HasPrefix(worktreeDir, repoPath) {
 		relPath, _ := filepath.Rel(repoPath, worktreeDir)
 		if relPath != "" && !strings.HasPrefix(relPath, "..") {
-			if err := ensureGitignoreEntry(repoPath, relPath); err != nil {
-				// Don't fail the worktree creation if we can't update .gitignore
+			if err := ensureNoTrackedFiles(repoPath, relPath); err != nil {
+				return err
+			}
+			if err := ensureGitExcludeEntry(repoPath, relPath); err != nil {
+				// Don't fail the worktree creation if we can't update git excludes
 				// Just continue with a warning
-				fmt.Fprintf(os.Stderr, "Warning: Could not update .gitignore: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Warning: Could not update git excludes: %v\n", err)
 			}
 		}
 	}

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func buildBinary(t *testing.T) string {
+	t.Helper()
+
+	projectRoot, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working dir: %v", err)
+	}
+
+	binDir := t.TempDir()
+	binaryPath := filepath.Join(binDir, "gt")
+
+	cmd := exec.Command("go", "build", "-o", binaryPath, ".")
+	cmd.Dir = projectRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build failed: %v\n%s", err, output)
+	}
+
+	return binaryPath
+}
+
+func TestGTRunCreatesWorktreeAndUpdatesExcludes(t *testing.T) {
+	repoPath := initRepo(t)
+	binaryPath := buildBinary(t)
+
+	cmd := exec.Command(binaryPath, "-x", "true", "feature-branch")
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	worktreePath := filepath.Join(repoPath, defaultWorktreeDir, "feature-branch")
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("expected worktree to exist: %v", err)
+	}
+
+	excludePath, err := gitExcludePath(repoPath)
+	if err != nil {
+		t.Fatalf("resolve git excludes path: %v", err)
+	}
+
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read git excludes: %v", err)
+	}
+
+	entry := defaultWorktreeDir + "/"
+	if !strings.Contains(string(content), entry) {
+		t.Fatalf("expected %q in git excludes", entry)
+	}
+}

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestEnsureNoTrackedFilesFailsForWorktreeDir(t *testing.T) {
+	repoPath := initRepo(t)
+
+	worktreeDir := filepath.Join(repoPath, defaultWorktreeDir)
+	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+		t.Fatalf("create worktree dir: %v", err)
+	}
+
+	trackedFile := filepath.Join(worktreeDir, "tracked.txt")
+	if err := os.WriteFile(trackedFile, []byte("tracked"), 0644); err != nil {
+		t.Fatalf("write tracked file: %v", err)
+	}
+
+	runGit(t, repoPath, "add", filepath.ToSlash(filepath.Join(defaultWorktreeDir, "tracked.txt")))
+
+	if err := ensureNoTrackedFiles(repoPath, defaultWorktreeDir); err == nil {
+		t.Fatalf("expected tracked files error")
+	}
+}

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestEnsureGitExcludeEntryAddsEntry(t *testing.T) {
+	repoPath := initRepo(t)
+
+	if err := ensureGitExcludeEntry(repoPath, defaultWorktreeDir); err != nil {
+		t.Fatalf("ensure git exclude entry: %v", err)
+	}
+
+	if err := ensureGitExcludeEntry(repoPath, defaultWorktreeDir); err != nil {
+		t.Fatalf("ensure git exclude entry again: %v", err)
+	}
+
+	excludePath, err := gitExcludePath(repoPath)
+	if err != nil {
+		t.Fatalf("resolve git excludes path: %v", err)
+	}
+
+	content, err := os.ReadFile(excludePath)
+	if err != nil {
+		t.Fatalf("read git excludes: %v", err)
+	}
+
+	entry := defaultWorktreeDir + "/"
+	if !strings.Contains(string(content), entry) {
+		t.Fatalf("expected %q in git excludes", entry)
+	}
+	if strings.Count(string(content), entry) != 1 {
+		t.Fatalf("expected single %q entry in git excludes", entry)
+	}
+}

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func runGit(t *testing.T, repoPath string, args ...string) []byte {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+
+	return output
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+
+	repoPath := t.TempDir()
+	runGit(t, repoPath, "init")
+
+	readmePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("test"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	runGit(t, repoPath, "add", "README.md")
+	runGit(t, repoPath, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+
+	return repoPath
+}


### PR DESCRIPTION
## Summary
- write worktree ignore entries to `.git/info/exclude` instead of editing `.gitignore`
- fail worktree creation when the configured worktree directory has tracked files
- add unit, integration, and e2e coverage for worktree ignore behavior

## Testing
- `go test ./... -run TestEnsureGitExcludeEntryAddsEntry`
- `go test ./... -run TestEnsureNoTrackedFilesFailsForWorktreeDir`
- `go test ./... -run TestGTRunCreatesWorktreeAndUpdatesExcludes`