### PR TITLE
Honor XDG_CONFIG_HOME config path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Honor `XDG_CONFIG_HOME` for config lookup before platform defaults
+
 ## [0.4.0] - 2026-01-22
 
 ### Fixed

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetConfigPathPrefersXdgConfigHome(t *testing.T) {
+	xdgConfigHome := filepath.Join(t.TempDir(), "xdg")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	configPath := getConfigPath()
+	expected := filepath.Join(xdgConfigHome, configDirName, configFileName)
+	if configPath != expected {
+		t.Fatalf("expected config path %q, got %q", expected, configPath)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -243,6 +243,10 @@ func truncateString(s string, maxLen int) string {
 }
 
 func getConfigPath() string {
+	if xdgConfigHome := strings.TrimSpace(os.Getenv("XDG_CONFIG_HOME")); xdgConfigHome != "" {
+		return filepath.Join(xdgConfigHome, configDirName, configFileName)
+	}
+
 	configHome, err := os.UserConfigDir()
 	if err != nil {
 		home, _ := os.UserHomeDir()


### PR DESCRIPTION
## Summary
- read config from XDG_CONFIG_HOME before falling back to os.UserConfigDir
- add a unit test covering the XDG_CONFIG_HOME lookup

Closing #5

## Testing
- go test ./...