### PR TITLE
Show worktree subpath when custom

### DIFF
--- a/main.go
+++ b/main.go
@@ -1857,28 +1857,35 @@ func (m model) View() string {
 			relTime := formatRelativeTime(wt.LastCommit.Date)
 			commitText := fmt.Sprintf("%s (%s)", commitMsg, relTime)
 
-			// Build folder label: "📂 name" if it fits, just "📂" if tight
+			// Build folder label: "[📂 name]" if it fits, just "[📂]" if tight
 			folderLabel := ""
 			if hasFolderMismatch {
-				statusSuffix := fmt.Sprintf(" %s%s  ", status, aheadBehind)
+				tail := fmt.Sprintf(" │ %s%s  ", status, aheadBehind)
 				basePrefix := fmt.Sprintf("%s%-*s", cursor, branchDisplayWidth, branch)
-				basePrefixWidth := lipgloss.Width(basePrefix) + lipgloss.Width(statusSuffix)
+				basePrefixWidth := lipgloss.Width(basePrefix) + lipgloss.Width(tail)
 
-				fullLabel := " " + dimStyle.Render("📂 "+folderName)
+				fullLabel := " " + dimStyle.Render("[📂 "+folderName+"]")
 				commitWidth := lipgloss.Width(commitText)
 				if m.ui.width <= 0 || basePrefixWidth+lipgloss.Width(fullLabel)+commitWidth <= m.ui.width {
 					folderLabel = fullLabel
 				} else {
-					folderLabel = " " + dimStyle.Render("📂")
+					folderLabel = " " + dimStyle.Render("[📂]")
 				}
 			}
 
-			// Format line: cursor branch [📂 name] status ahead/behind  commit
-			prefix := fmt.Sprintf("%s%-*s%s %s%s  ",
+			// Format line: cursor branch [📂 name] │ status ahead/behind  commit
+			var separator string
+			if hasFolderMismatch {
+				separator = " │ "
+			} else {
+				separator = " "
+			}
+			prefix := fmt.Sprintf("%s%-*s%s%s%s%s ",
 				cursor,
 				branchDisplayWidth,
 				branch,
 				folderLabel,
+				separator,
 				status,
 				aheadBehind,
 			)

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
+
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +17,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/mattn/go-runewidth"
+
 )
 
 const (
@@ -35,9 +35,7 @@ const (
 	hashDisplayLength    = 7
 	branchDisplayWidth   = 20
 	ellipsis             = "..."
-	commitDetailShare    = 0.6
-	minCommitDetailWidth = 10
-	minPathDetailWidth   = 8
+
 
 	// Git command timeouts
 	gitCmdTimeout     = 5 * time.Second
@@ -281,150 +279,42 @@ func truncateString(s string, maxLen int) string {
 	return string(runes[:maxLen]) + ellipsis
 }
 
-func truncateStringByWidth(s string, maxWidth int) string {
+// truncateToWidth truncates a string to fit within maxWidth display columns,
+// adding an ellipsis suffix if truncation is needed.
+func truncateToWidth(s string, maxWidth int) string {
 	if maxWidth <= 0 {
 		return ""
 	}
 	if lipgloss.Width(s) <= maxWidth {
 		return s
 	}
-	if maxWidth <= lipgloss.Width(ellipsis) {
-		return strings.Repeat(".", maxWidth)
+	ellipsisWidth := lipgloss.Width(ellipsis)
+	if maxWidth <= ellipsisWidth {
+		return ellipsis[:maxWidth]
 	}
-
-	var b strings.Builder
-	width := 0
-	limit := maxWidth - lipgloss.Width(ellipsis)
-	for _, r := range s {
-		rw := runewidth.RuneWidth(r)
-		if width+rw > limit {
-			break
-		}
-		b.WriteRune(r)
-		width += rw
-	}
-	return b.String() + ellipsis
-}
-
-func tailStringByWidth(s string, maxWidth int) string {
-	if maxWidth <= 0 {
-		return ""
-	}
-	if lipgloss.Width(s) <= maxWidth {
-		return s
-	}
-
 	runes := []rune(s)
 	width := 0
-	i := len(runes)
-	for i > 0 {
-		rw := runewidth.RuneWidth(runes[i-1])
-		if width+rw > maxWidth {
-			break
+	for i, r := range runes {
+		rw := lipgloss.Width(string(r))
+		if width+rw > maxWidth-ellipsisWidth {
+			return string(runes[:i]) + ellipsis
 		}
 		width += rw
-		i--
 	}
-	return string(runes[i:])
-}
-
-func truncatePathTail(path string, maxWidth int) string {
-	if maxWidth <= 0 {
-		return ""
-	}
-	clean := filepath.ToSlash(path)
-	if lipgloss.Width(clean) <= maxWidth {
-		return clean
-	}
-	if maxWidth <= lipgloss.Width(ellipsis) {
-		return strings.Repeat(".", maxWidth)
-	}
-
-	parts := strings.Split(clean, "/")
-	filtered := parts[:0]
-	for _, part := range parts {
-		if part != "" {
-			filtered = append(filtered, part)
-		}
-	}
-	if len(filtered) == 0 {
-		return truncateStringByWidth(clean, maxWidth)
-	}
-
-	prefix := ellipsis + "/"
-	remainingWidth := maxWidth - lipgloss.Width(prefix)
-	if remainingWidth <= 0 {
-		return strings.Repeat(".", maxWidth)
-	}
-
-	tail := filtered[len(filtered)-1]
-	if lipgloss.Width(tail) > remainingWidth {
-		return prefix + tailStringByWidth(tail, remainingWidth)
-	}
-
-	for i := len(filtered) - 2; i >= 0; i-- {
-		candidate := filtered[i] + "/" + tail
-		if lipgloss.Width(candidate)+lipgloss.Width(prefix) > maxWidth {
-			break
-		}
-		tail = candidate
-	}
-
-	return prefix + tail
+	return s
 }
 
 func formatWorktreeDetail(commitText, subPath string, showSubPath bool, maxWidth int) string {
-	if maxWidth <= 0 {
-		if showSubPath {
-			return fmt.Sprintf("%s (%s)", commitText, subPath)
+	if showSubPath {
+		full := fmt.Sprintf("%s (%s)", commitText, subPath)
+		if maxWidth <= 0 || lipgloss.Width(full) <= maxWidth {
+			return full
 		}
+	}
+	if maxWidth <= 0 {
 		return commitText
 	}
-
-	if !showSubPath {
-		return truncateStringByWidth(commitText, maxWidth)
-	}
-
-	overheadWidth := lipgloss.Width(" ()")
-	availableWidth := maxWidth - overheadWidth
-	if availableWidth <= 0 {
-		return truncateStringByWidth(commitText, maxWidth)
-	}
-
-	commitAlloc := int(math.Round(float64(availableWidth) * commitDetailShare))
-	pathAlloc := availableWidth - commitAlloc
-	if availableWidth >= minCommitDetailWidth+minPathDetailWidth {
-		if commitAlloc < minCommitDetailWidth {
-			commitAlloc = minCommitDetailWidth
-		}
-		if pathAlloc < minPathDetailWidth {
-			pathAlloc = minPathDetailWidth
-		}
-		if commitAlloc+pathAlloc > availableWidth {
-			overflow := commitAlloc + pathAlloc - availableWidth
-			if commitAlloc >= pathAlloc {
-				commitAlloc -= overflow
-			} else {
-				pathAlloc -= overflow
-			}
-		}
-	} else {
-		commitAlloc = availableWidth / 2
-		if commitAlloc < 1 {
-			commitAlloc = 1
-		}
-		pathAlloc = availableWidth - commitAlloc
-		if pathAlloc < 1 {
-			pathAlloc = 1
-			if commitAlloc > 1 {
-				commitAlloc--
-			}
-		}
-	}
-
-	commitText = truncateStringByWidth(commitText, commitAlloc)
-	pathText := truncatePathTail(subPath, pathAlloc)
-	return fmt.Sprintf("%s (%s)", commitText, pathText)
+	return truncateToWidth(commitText, maxWidth)
 }
 
 func worktreeDirForConfig(repoPath string, config *Config) string {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,7 +16,6 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-
 )
 
 const (
@@ -35,7 +33,6 @@ const (
 	hashDisplayLength    = 7
 	branchDisplayWidth   = 20
 	ellipsis             = "..."
-
 
 	// Git command timeouts
 	gitCmdTimeout     = 5 * time.Second
@@ -162,15 +159,16 @@ type mergeState struct {
 
 // model is the Bubble Tea model for the TUI application.
 type model struct {
-	ui       uiState
-	wt       worktreeState
-	acts     actionsState
-	del      deleteState
-	merge    mergeState
-	repoPath string
-	config   *Config
-	err      error
-	status   struct {
+	ui              uiState
+	wt              worktreeState
+	acts            actionsState
+	del             deleteState
+	merge           mergeState
+	repoPath        string
+	mainWorktreeDir string
+	config          *Config
+	err             error
+	status          struct {
 		message string
 		isError bool
 		timeout time.Time
@@ -304,19 +302,6 @@ func truncateToWidth(s string, maxWidth int) string {
 	return s
 }
 
-func formatWorktreeDetail(commitText, subPath string, showSubPath bool, maxWidth int) string {
-	if showSubPath {
-		full := fmt.Sprintf("%s (%s)", commitText, subPath)
-		if maxWidth <= 0 || lipgloss.Width(full) <= maxWidth {
-			return full
-		}
-	}
-	if maxWidth <= 0 {
-		return commitText
-	}
-	return truncateToWidth(commitText, maxWidth)
-}
-
 func worktreeDirForConfig(repoPath string, config *Config) string {
 	worktreeDir := defaultWorktreeDir
 	if config != nil && config.WorktreeDir != "" {
@@ -328,22 +313,24 @@ func worktreeDirForConfig(repoPath string, config *Config) string {
 	return filepath.Clean(worktreeDir)
 }
 
-func expectedWorktreePath(repoPath, branch string, config *Config) string {
-	if branch == "" {
-		return ""
+// isExpectedWorktreePath checks whether the worktree folder name matches
+// the convention for the given branch (slashes replaced with dashes).
+func isExpectedWorktreePath(branch, worktreePath string) bool {
+	if branch == "" || worktreePath == "" {
+		return true
 	}
-	worktreeDir := worktreeDirForConfig(repoPath, config)
-	worktreeName := strings.ReplaceAll(branch, "/", "-")
-	return filepath.Clean(filepath.Join(worktreeDir, worktreeName))
+	expectedName := strings.ReplaceAll(branch, "/", "-")
+	actualName := filepath.Base(filepath.Clean(worktreePath))
+	return actualName == expectedName
 }
 
-func worktreeSubPath(repoPath string, config *Config, worktreePath string) string {
+func worktreeSubPath(mainWorktreeDir string, config *Config, worktreePath string) string {
 	cleanPath := filepath.Clean(worktreePath)
-	worktreeDir := worktreeDirForConfig(repoPath, config)
+	worktreeDir := worktreeDirForConfig(mainWorktreeDir, config)
 	if rel, err := filepath.Rel(worktreeDir, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
 		return filepath.ToSlash(rel)
 	}
-	if rel, err := filepath.Rel(repoPath, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+	if rel, err := filepath.Rel(mainWorktreeDir, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
 		return filepath.ToSlash(rel)
 	}
 	return filepath.ToSlash(cleanPath)
@@ -787,9 +774,10 @@ func tickCmd() tea.Cmd {
 
 // worktreesLoadedMsg is sent when async worktree loading completes.
 type worktreesLoadedMsg struct {
-	worktrees     []Worktree
-	defaultBranch string
-	err           error
+	worktrees       []Worktree
+	defaultBranch   string
+	mainWorktreeDir string
+	err             error
 }
 
 // worktreeDetailLoadedMsg reports incremental detail updates for a single worktree.
@@ -836,10 +824,15 @@ func loadWorktreesCmd(repoPath string) tea.Cmd {
 		ctx, cancel := context.WithTimeout(context.Background(), gitCmdSlowTimeout)
 		defer cancel()
 		worktrees, defaultBranch, err := listWorktreesWithContext(ctx, repoPath)
+		var mainDir string
+		if len(worktrees) > 0 {
+			mainDir = worktrees[0].Path
+		}
 		return worktreesLoadedMsg{
-			worktrees:     worktrees,
-			defaultBranch: defaultBranch,
-			err:           err,
+			worktrees:       worktrees,
+			defaultBranch:   defaultBranch,
+			mainWorktreeDir: mainDir,
+			err:             err,
 		}
 	}
 }
@@ -1289,6 +1282,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.wt.worktrees = msg.worktrees
 		m.wt.filtered = filterWorktrees(msg.worktrees, m.wt.searchTerm)
 		m.wt.defaultBranch = msg.defaultBranch
+		m.mainWorktreeDir = msg.mainWorktreeDir
 		m.wt.detailGeneration++
 		m.resetDetailQueue()
 		// Find current worktree path for tracking previous (session-only)
@@ -1854,6 +1848,21 @@ func (m model) View() string {
 				branch = branchStyle.Render(branch)
 			}
 
+			// Worktree folder path — only for non-main worktrees with unexpected names
+			isMainWorktree := filepath.Clean(wt.Path) == filepath.Clean(m.mainWorktreeDir)
+			showSubPath := false
+			subPath := ""
+			if !isMainWorktree && !isExpectedWorktreePath(wt.Branch, wt.Path) {
+				showSubPath = true
+				subPath = worktreeSubPath(m.mainWorktreeDir, m.config, wt.Path)
+			}
+
+			// Folder path label (placed after branch name)
+			folderLabel := ""
+			if showSubPath {
+				folderLabel = " " + dimStyle.Render(fmt.Sprintf("(%s)", subPath))
+			}
+
 			// Status indicator
 			status := "✓"
 			if wt.IsDirty {
@@ -1878,21 +1887,12 @@ func (m model) View() string {
 			relTime := formatRelativeTime(wt.LastCommit.Date)
 			commitText := fmt.Sprintf("%s (%s)", commitMsg, relTime)
 
-			showSubPath := false
-			subPath := ""
-			if expected := expectedWorktreePath(m.repoPath, wt.Branch, m.config); expected != "" {
-				actualPath := filepath.Clean(wt.Path)
-				if actualPath != expected {
-					showSubPath = true
-					subPath = worktreeSubPath(m.repoPath, m.config, actualPath)
-				}
-			}
-
-			// Format line
-			prefix := fmt.Sprintf("%s%-*s %s%s  ",
+			// Format line: cursor branch (folder) status ahead/behind  commit
+			prefix := fmt.Sprintf("%s%-*s%s %s%s  ",
 				cursor,
 				branchDisplayWidth,
 				branch,
+				folderLabel,
 				status,
 				aheadBehind,
 			)
@@ -1900,7 +1900,7 @@ func (m model) View() string {
 			if m.ui.width > 0 {
 				maxDetailWidth = m.ui.width - lipgloss.Width(prefix)
 			}
-			detailText := formatWorktreeDetail(commitText, subPath, showSubPath, maxDetailWidth)
+			detailText := truncateToWidth(commitText, maxDetailWidth)
 
 			line := fmt.Sprintf("%s%s",
 				prefix,

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,6 +35,9 @@ const (
 	hashDisplayLength    = 7
 	branchDisplayWidth   = 20
 	ellipsis             = "..."
+	commitDetailShare    = 0.6
+	minCommitDetailWidth = 10
+	minPathDetailWidth   = 8
 
 	// Git command timeouts
 	gitCmdTimeout     = 5 * time.Second
@@ -300,6 +304,127 @@ func truncateStringByWidth(s string, maxWidth int) string {
 		width += rw
 	}
 	return b.String() + ellipsis
+}
+
+func tailStringByWidth(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+
+	runes := []rune(s)
+	width := 0
+	i := len(runes)
+	for i > 0 {
+		rw := runewidth.RuneWidth(runes[i-1])
+		if width+rw > maxWidth {
+			break
+		}
+		width += rw
+		i--
+	}
+	return string(runes[i:])
+}
+
+func truncatePathTail(path string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	clean := filepath.ToSlash(path)
+	if lipgloss.Width(clean) <= maxWidth {
+		return clean
+	}
+	if maxWidth <= lipgloss.Width(ellipsis) {
+		return strings.Repeat(".", maxWidth)
+	}
+
+	parts := strings.Split(clean, "/")
+	filtered := parts[:0]
+	for _, part := range parts {
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	if len(filtered) == 0 {
+		return truncateStringByWidth(clean, maxWidth)
+	}
+
+	prefix := ellipsis + "/"
+	remainingWidth := maxWidth - lipgloss.Width(prefix)
+	if remainingWidth <= 0 {
+		return strings.Repeat(".", maxWidth)
+	}
+
+	tail := filtered[len(filtered)-1]
+	if lipgloss.Width(tail) > remainingWidth {
+		return prefix + tailStringByWidth(tail, remainingWidth)
+	}
+
+	for i := len(filtered) - 2; i >= 0; i-- {
+		candidate := filtered[i] + "/" + tail
+		if lipgloss.Width(candidate)+lipgloss.Width(prefix) > maxWidth {
+			break
+		}
+		tail = candidate
+	}
+
+	return prefix + tail
+}
+
+func formatWorktreeDetail(commitText, subPath string, showSubPath bool, maxWidth int) string {
+	if maxWidth <= 0 {
+		if showSubPath {
+			return fmt.Sprintf("%s (%s)", commitText, subPath)
+		}
+		return commitText
+	}
+
+	if !showSubPath {
+		return truncateStringByWidth(commitText, maxWidth)
+	}
+
+	overheadWidth := lipgloss.Width(" ()")
+	availableWidth := maxWidth - overheadWidth
+	if availableWidth <= 0 {
+		return truncateStringByWidth(commitText, maxWidth)
+	}
+
+	commitAlloc := int(math.Round(float64(availableWidth) * commitDetailShare))
+	pathAlloc := availableWidth - commitAlloc
+	if availableWidth >= minCommitDetailWidth+minPathDetailWidth {
+		if commitAlloc < minCommitDetailWidth {
+			commitAlloc = minCommitDetailWidth
+		}
+		if pathAlloc < minPathDetailWidth {
+			pathAlloc = minPathDetailWidth
+		}
+		if commitAlloc+pathAlloc > availableWidth {
+			overflow := commitAlloc + pathAlloc - availableWidth
+			if commitAlloc >= pathAlloc {
+				commitAlloc -= overflow
+			} else {
+				pathAlloc -= overflow
+			}
+		}
+	} else {
+		commitAlloc = availableWidth / 2
+		if commitAlloc < 1 {
+			commitAlloc = 1
+		}
+		pathAlloc = availableWidth - commitAlloc
+		if pathAlloc < 1 {
+			pathAlloc = 1
+			if commitAlloc > 1 {
+				commitAlloc--
+			}
+		}
+	}
+
+	commitText = truncateStringByWidth(commitText, commitAlloc)
+	pathText := truncatePathTail(subPath, pathAlloc)
+	return fmt.Sprintf("%s (%s)", commitText, pathText)
 }
 
 func worktreeDirForConfig(repoPath string, config *Config) string {
@@ -1873,12 +1998,6 @@ func (m model) View() string {
 				}
 			}
 
-			detailText := commitText
-			sep := " · "
-			if showSubPath {
-				detailText = subPath + sep + commitText
-			}
-
 			// Format line
 			prefix := fmt.Sprintf("%s%-*s %s%s  ",
 				cursor,
@@ -1887,28 +2006,11 @@ func (m model) View() string {
 				status,
 				aheadBehind,
 			)
+			maxDetailWidth := 0
 			if m.ui.width > 0 {
-				maxDetailWidth := m.ui.width - lipgloss.Width(prefix)
-				if maxDetailWidth > 0 && lipgloss.Width(detailText) > maxDetailWidth {
-					if showSubPath {
-						commitWidth := lipgloss.Width(commitText)
-						sepWidth := lipgloss.Width(sep)
-						if commitWidth >= maxDetailWidth {
-							detailText = truncateStringByWidth(commitText, maxDetailWidth)
-						} else {
-							pathWidth := maxDetailWidth - commitWidth - sepWidth
-							if pathWidth <= 0 {
-								detailText = truncateStringByWidth(commitText, maxDetailWidth)
-							} else {
-								truncatedPath := truncateStringByWidth(subPath, pathWidth)
-								detailText = truncatedPath + sep + commitText
-							}
-						}
-					} else {
-						detailText = truncateStringByWidth(detailText, maxDetailWidth)
-					}
-				}
+				maxDetailWidth = m.ui.width - lipgloss.Width(prefix)
 			}
+			detailText := formatWorktreeDetail(commitText, subPath, showSubPath, maxDetailWidth)
 
 			line := fmt.Sprintf("%s%s",
 				prefix,

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/mattn/go-runewidth"
 )
 
 const (
@@ -274,6 +275,63 @@ func truncateString(s string, maxLen int) string {
 	}
 	runes := []rune(s)
 	return string(runes[:maxLen]) + ellipsis
+}
+
+func truncateStringByWidth(s string, maxWidth int) string {
+	if maxWidth <= 0 {
+		return ""
+	}
+	if lipgloss.Width(s) <= maxWidth {
+		return s
+	}
+	if maxWidth <= lipgloss.Width(ellipsis) {
+		return strings.Repeat(".", maxWidth)
+	}
+
+	var b strings.Builder
+	width := 0
+	limit := maxWidth - lipgloss.Width(ellipsis)
+	for _, r := range s {
+		rw := runewidth.RuneWidth(r)
+		if width+rw > limit {
+			break
+		}
+		b.WriteRune(r)
+		width += rw
+	}
+	return b.String() + ellipsis
+}
+
+func worktreeDirForConfig(repoPath string, config *Config) string {
+	worktreeDir := defaultWorktreeDir
+	if config != nil && config.WorktreeDir != "" {
+		worktreeDir = config.WorktreeDir
+	}
+	if !filepath.IsAbs(worktreeDir) {
+		worktreeDir = filepath.Join(repoPath, worktreeDir)
+	}
+	return filepath.Clean(worktreeDir)
+}
+
+func expectedWorktreePath(repoPath, branch string, config *Config) string {
+	if branch == "" {
+		return ""
+	}
+	worktreeDir := worktreeDirForConfig(repoPath, config)
+	worktreeName := strings.ReplaceAll(branch, "/", "-")
+	return filepath.Clean(filepath.Join(worktreeDir, worktreeName))
+}
+
+func worktreeSubPath(repoPath string, config *Config, worktreePath string) string {
+	cleanPath := filepath.Clean(worktreePath)
+	worktreeDir := worktreeDirForConfig(repoPath, config)
+	if rel, err := filepath.Rel(worktreeDir, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	if rel, err := filepath.Rel(repoPath, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+		return filepath.ToSlash(rel)
+	}
+	return filepath.ToSlash(cleanPath)
 }
 
 func getConfigPath() string {
@@ -1803,15 +1861,58 @@ func (m model) View() string {
 			// Commit info
 			commitMsg := truncateString(wt.LastCommit.Message, maxCommitMsgLength)
 			relTime := formatRelativeTime(wt.LastCommit.Date)
+			commitText := fmt.Sprintf("%s (%s)", commitMsg, relTime)
+
+			showSubPath := false
+			subPath := ""
+			if expected := expectedWorktreePath(m.repoPath, wt.Branch, m.config); expected != "" {
+				actualPath := filepath.Clean(wt.Path)
+				if actualPath != expected {
+					showSubPath = true
+					subPath = worktreeSubPath(m.repoPath, m.config, actualPath)
+				}
+			}
+
+			detailText := commitText
+			sep := " · "
+			if showSubPath {
+				detailText = subPath + sep + commitText
+			}
 
 			// Format line
-			line := fmt.Sprintf("%s%-*s %s%s  %s",
+			prefix := fmt.Sprintf("%s%-*s %s%s  ",
 				cursor,
 				branchDisplayWidth,
 				branch,
 				status,
 				aheadBehind,
-				dimStyle.Render(fmt.Sprintf("%s (%s)", commitMsg, relTime)),
+			)
+			if m.ui.width > 0 {
+				maxDetailWidth := m.ui.width - lipgloss.Width(prefix)
+				if maxDetailWidth > 0 && lipgloss.Width(detailText) > maxDetailWidth {
+					if showSubPath {
+						commitWidth := lipgloss.Width(commitText)
+						sepWidth := lipgloss.Width(sep)
+						if commitWidth >= maxDetailWidth {
+							detailText = truncateStringByWidth(commitText, maxDetailWidth)
+						} else {
+							pathWidth := maxDetailWidth - commitWidth - sepWidth
+							if pathWidth <= 0 {
+								detailText = truncateStringByWidth(commitText, maxDetailWidth)
+							} else {
+								truncatedPath := truncateStringByWidth(subPath, pathWidth)
+								detailText = truncatedPath + sep + commitText
+							}
+						}
+					} else {
+						detailText = truncateStringByWidth(detailText, maxDetailWidth)
+					}
+				}
+			}
+
+			line := fmt.Sprintf("%s%s",
+				prefix,
+				dimStyle.Render(detailText),
 			)
 
 			if i == m.ui.cursor {

--- a/main.go
+++ b/main.go
@@ -1825,11 +1825,12 @@ func (m model) View() string {
 				branch = branchStyle.Render(branch)
 			}
 
-			// Folder mismatch indicator — shown when folder name doesn't match branch
+			// Folder mismatch — shown when folder name doesn't match branch
 			isMainWorktree := filepath.Clean(wt.Path) == filepath.Clean(m.mainWorktreeDir)
-			folderIndicator := ""
-			if !isMainWorktree && !isExpectedWorktreePath(wt.Branch, wt.Path) {
-				folderIndicator = " " + dimStyle.Render("⧉")
+			hasFolderMismatch := !isMainWorktree && !isExpectedWorktreePath(wt.Branch, wt.Path)
+			folderName := ""
+			if hasFolderMismatch {
+				folderName = filepath.Base(filepath.Clean(wt.Path))
 			}
 
 			// Status indicator
@@ -1856,12 +1857,28 @@ func (m model) View() string {
 			relTime := formatRelativeTime(wt.LastCommit.Date)
 			commitText := fmt.Sprintf("%s (%s)", commitMsg, relTime)
 
-			// Format line: cursor branch [⧉] status ahead/behind  commit
+			// Build folder label: "📂 name" if it fits, just "📂" if tight
+			folderLabel := ""
+			if hasFolderMismatch {
+				statusSuffix := fmt.Sprintf(" %s%s  ", status, aheadBehind)
+				basePrefix := fmt.Sprintf("%s%-*s", cursor, branchDisplayWidth, branch)
+				basePrefixWidth := lipgloss.Width(basePrefix) + lipgloss.Width(statusSuffix)
+
+				fullLabel := " " + dimStyle.Render("📂 "+folderName)
+				commitWidth := lipgloss.Width(commitText)
+				if m.ui.width <= 0 || basePrefixWidth+lipgloss.Width(fullLabel)+commitWidth <= m.ui.width {
+					folderLabel = fullLabel
+				} else {
+					folderLabel = " " + dimStyle.Render("📂")
+				}
+			}
+
+			// Format line: cursor branch [📂 name] status ahead/behind  commit
 			prefix := fmt.Sprintf("%s%-*s%s %s%s  ",
 				cursor,
 				branchDisplayWidth,
 				branch,
-				folderIndicator,
+				folderLabel,
 				status,
 				aheadBehind,
 			)

--- a/main.go
+++ b/main.go
@@ -302,17 +302,6 @@ func truncateToWidth(s string, maxWidth int) string {
 	return s
 }
 
-func worktreeDirForConfig(repoPath string, config *Config) string {
-	worktreeDir := defaultWorktreeDir
-	if config != nil && config.WorktreeDir != "" {
-		worktreeDir = config.WorktreeDir
-	}
-	if !filepath.IsAbs(worktreeDir) {
-		worktreeDir = filepath.Join(repoPath, worktreeDir)
-	}
-	return filepath.Clean(worktreeDir)
-}
-
 // isExpectedWorktreePath checks whether the worktree folder name matches
 // the convention for the given branch (slashes replaced with dashes).
 func isExpectedWorktreePath(branch, worktreePath string) bool {
@@ -322,18 +311,6 @@ func isExpectedWorktreePath(branch, worktreePath string) bool {
 	expectedName := strings.ReplaceAll(branch, "/", "-")
 	actualName := filepath.Base(filepath.Clean(worktreePath))
 	return actualName == expectedName
-}
-
-func worktreeSubPath(mainWorktreeDir string, config *Config, worktreePath string) string {
-	cleanPath := filepath.Clean(worktreePath)
-	worktreeDir := worktreeDirForConfig(mainWorktreeDir, config)
-	if rel, err := filepath.Rel(worktreeDir, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-		return filepath.ToSlash(rel)
-	}
-	if rel, err := filepath.Rel(mainWorktreeDir, cleanPath); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
-		return filepath.ToSlash(rel)
-	}
-	return filepath.ToSlash(cleanPath)
 }
 
 func getConfigPath() string {
@@ -1848,19 +1825,11 @@ func (m model) View() string {
 				branch = branchStyle.Render(branch)
 			}
 
-			// Worktree folder path — only for non-main worktrees with unexpected names
+			// Folder mismatch indicator — shown when folder name doesn't match branch
 			isMainWorktree := filepath.Clean(wt.Path) == filepath.Clean(m.mainWorktreeDir)
-			showSubPath := false
-			subPath := ""
+			folderIndicator := ""
 			if !isMainWorktree && !isExpectedWorktreePath(wt.Branch, wt.Path) {
-				showSubPath = true
-				subPath = worktreeSubPath(m.mainWorktreeDir, m.config, wt.Path)
-			}
-
-			// Folder path label (placed after branch name)
-			folderLabel := ""
-			if showSubPath {
-				folderLabel = " " + dimStyle.Render(fmt.Sprintf("(%s)", subPath))
+				folderIndicator = " " + dimStyle.Render("⧉")
 			}
 
 			// Status indicator
@@ -1887,12 +1856,12 @@ func (m model) View() string {
 			relTime := formatRelativeTime(wt.LastCommit.Date)
 			commitText := fmt.Sprintf("%s (%s)", commitMsg, relTime)
 
-			// Format line: cursor branch (folder) status ahead/behind  commit
+			// Format line: cursor branch [⧉] status ahead/behind  commit
 			prefix := fmt.Sprintf("%s%-*s%s %s%s  ",
 				cursor,
 				branchDisplayWidth,
 				branch,
-				folderLabel,
+				folderIndicator,
 				status,
 				aheadBehind,
 			)

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -5,8 +5,6 @@ import (
 	"strings"
 	"testing"
 	"time"
-
-
 )
 
 func TestEnsureGitExcludeEntryAddsEntry(t *testing.T) {
@@ -129,70 +127,48 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
-func TestFormatWorktreeDetail(t *testing.T) {
+func TestIsExpectedWorktreePath(t *testing.T) {
 	tests := []struct {
-		name        string
-		commitText  string
-		subPath     string
-		showSubPath bool
-		maxWidth    int
-		want        string
+		name         string
+		branch       string
+		worktreePath string
+		want         bool
 	}{
-		{
-			name:        "shows subpath when it fits",
-			commitText:  "Fix crash (2h ago)",
-			subPath:     "my-tree",
-			showSubPath: true,
-			maxWidth:    40,
-			want:        "Fix crash (2h ago) (my-tree)",
-		},
-		{
-			name:        "hides subpath when it does not fit",
-			commitText:  "Fix crash (2h ago)",
-			subPath:     "custom/worktrees/feature-branch",
-			showSubPath: true,
-			maxWidth:    28,
-			want:        "Fix crash (2h ago)",
-		},
-		{
-			name:        "truncates commit text when no subpath",
-			commitText:  "Fix crash (2h ago)",
-			subPath:     "",
-			showSubPath: false,
-			maxWidth:    12,
-			want:        "Fix crash...",
-		},
-		{
-			name:        "truncates commit text when subpath hidden due to space",
-			commitText:  "A very long commit message (2h ago)",
-			subPath:     "worktrees/feature",
-			showSubPath: true,
-			maxWidth:    20,
-			want:        "A very long commi...",
-		},
-		{
-			name:        "no width limit with subpath",
-			commitText:  "Fix crash (2h ago)",
-			subPath:     "worktrees/feature",
-			showSubPath: true,
-			maxWidth:    0,
-			want:        "Fix crash (2h ago) (worktrees/feature)",
-		},
-		{
-			name:        "no width limit without subpath",
-			commitText:  "Fix crash (2h ago)",
-			subPath:     "",
-			showSubPath: false,
-			maxWidth:    0,
-			want:        "Fix crash (2h ago)",
-		},
+		{"matching simple branch", "add-orm", "/repo/.worktrees/add-orm", true},
+		{"matching branch with slash", "feature/login", "/repo/.worktrees/feature-login", true},
+		{"non-matching folder", "add-orm", "/repo/.worktrees/custom-name", false},
+		{"empty branch", "", "/repo/.worktrees/whatever", true},
+		{"empty path", "main", "", true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := formatWorktreeDetail(tt.commitText, tt.subPath, tt.showSubPath, tt.maxWidth)
+			got := isExpectedWorktreePath(tt.branch, tt.worktreePath)
 			if got != tt.want {
-				t.Errorf("formatWorktreeDetail() = %q, want %q", got, tt.want)
+				t.Errorf("isExpectedWorktreePath(%q, %q) = %v, want %v", tt.branch, tt.worktreePath, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTruncateToWidth(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		maxWidth int
+		want     string
+	}{
+		{"fits within width", "hello", 10, "hello"},
+		{"truncates with ellipsis", "Fix crash (2h ago)", 12, "Fix crash..."},
+		{"zero width", "hello", 0, ""},
+		{"very small width", "hello world", 3, "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncateToWidth(tt.input, tt.maxWidth)
+			if got != tt.want {
+				t.Errorf("truncateToWidth(%q, %d) = %q, want %q", tt.input, tt.maxWidth, got, tt.want)
 			}
 		})
 	}

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestEnsureGitExcludeEntryAddsEntry(t *testing.T) {
@@ -124,6 +126,45 @@ func TestTruncateString(t *testing.T) {
 				t.Errorf("truncateString(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTruncatePathTail(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		maxWidth int
+		want     string
+	}{
+		{"fits without truncation", "worktrees/feature", 30, "worktrees/feature"},
+		{"truncates to last segment", "worktrees/feature", 8, ".../ture"},
+		{"keeps last segment", "custom/worktrees/feature-branch", 18, ".../feature-branch"},
+		{"truncates long last segment", "custom/worktrees/feature-branch", 14, ".../ure-branch"},
+		{"very small width", "custom/worktrees/feature-branch", 3, "..."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := truncatePathTail(tt.path, tt.maxWidth)
+			if got != tt.want {
+				t.Errorf("truncatePathTail(%q, %d) = %q, want %q", tt.path, tt.maxWidth, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatWorktreeDetail(t *testing.T) {
+	commitText := "Fix crash (2h ago)"
+	subPath := "custom/worktrees/feature-branch"
+
+	got := formatWorktreeDetail(commitText, subPath, true, 28)
+	want := "Fix crash (2... (.../branch)"
+	if got != want {
+		t.Errorf("formatWorktreeDetail() = %q, want %q", got, want)
+	}
+
+	if width := lipgloss.Width(got); width > 28 {
+		t.Errorf("formatWorktreeDetail() width = %d, want <= 28", width)
 	}
 }
 

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/lipgloss"
+
 )
 
 func TestEnsureGitExcludeEntryAddsEntry(t *testing.T) {
@@ -129,42 +129,72 @@ func TestTruncateString(t *testing.T) {
 	}
 }
 
-func TestTruncatePathTail(t *testing.T) {
+func TestFormatWorktreeDetail(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		maxWidth int
-		want     string
+		name        string
+		commitText  string
+		subPath     string
+		showSubPath bool
+		maxWidth    int
+		want        string
 	}{
-		{"fits without truncation", "worktrees/feature", 30, "worktrees/feature"},
-		{"truncates to last segment", "worktrees/feature", 8, ".../ture"},
-		{"keeps last segment", "custom/worktrees/feature-branch", 18, ".../feature-branch"},
-		{"truncates long last segment", "custom/worktrees/feature-branch", 14, ".../ure-branch"},
-		{"very small width", "custom/worktrees/feature-branch", 3, "..."},
+		{
+			name:        "shows subpath when it fits",
+			commitText:  "Fix crash (2h ago)",
+			subPath:     "my-tree",
+			showSubPath: true,
+			maxWidth:    40,
+			want:        "Fix crash (2h ago) (my-tree)",
+		},
+		{
+			name:        "hides subpath when it does not fit",
+			commitText:  "Fix crash (2h ago)",
+			subPath:     "custom/worktrees/feature-branch",
+			showSubPath: true,
+			maxWidth:    28,
+			want:        "Fix crash (2h ago)",
+		},
+		{
+			name:        "truncates commit text when no subpath",
+			commitText:  "Fix crash (2h ago)",
+			subPath:     "",
+			showSubPath: false,
+			maxWidth:    12,
+			want:        "Fix crash...",
+		},
+		{
+			name:        "truncates commit text when subpath hidden due to space",
+			commitText:  "A very long commit message (2h ago)",
+			subPath:     "worktrees/feature",
+			showSubPath: true,
+			maxWidth:    20,
+			want:        "A very long commi...",
+		},
+		{
+			name:        "no width limit with subpath",
+			commitText:  "Fix crash (2h ago)",
+			subPath:     "worktrees/feature",
+			showSubPath: true,
+			maxWidth:    0,
+			want:        "Fix crash (2h ago) (worktrees/feature)",
+		},
+		{
+			name:        "no width limit without subpath",
+			commitText:  "Fix crash (2h ago)",
+			subPath:     "",
+			showSubPath: false,
+			maxWidth:    0,
+			want:        "Fix crash (2h ago)",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := truncatePathTail(tt.path, tt.maxWidth)
+			got := formatWorktreeDetail(tt.commitText, tt.subPath, tt.showSubPath, tt.maxWidth)
 			if got != tt.want {
-				t.Errorf("truncatePathTail(%q, %d) = %q, want %q", tt.path, tt.maxWidth, got, tt.want)
+				t.Errorf("formatWorktreeDetail() = %q, want %q", got, tt.want)
 			}
 		})
-	}
-}
-
-func TestFormatWorktreeDetail(t *testing.T) {
-	commitText := "Fix crash (2h ago)"
-	subPath := "custom/worktrees/feature-branch"
-
-	got := formatWorktreeDetail(commitText, subPath, true, 28)
-	want := "Fix crash (2... (.../branch)"
-	if got != want {
-		t.Errorf("formatWorktreeDetail() = %q, want %q", got, want)
-	}
-
-	if width := lipgloss.Width(got); width > 28 {
-		t.Errorf("formatWorktreeDetail() width = %d, want <= 28", width)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a worktree's folder name doesn't match its checked-out branch (e.g. branch `feature/login` in folder `old-experiment`), show a visual indicator so users know the folder is non-standard.

## Display format

| Scenario | Display |
|----------|---------|
| Normal worktree | `branch ✓ ↑1  commit text (2h ago)` |
| Folder mismatch, wide terminal | `branch [📂 folder-name] │ ✓ ↑1  commit text (2h ago)` |
| Folder mismatch, narrow terminal | `branch [📂] │ ✓ ↑1  commit text (2h ago)` |

### Visibility rules

- **Main repo** (where `.git` lives): never shows folder indicator — it's always expected
- **Matching worktrees**: folder name matches the branch name convention (`/` → `-`) — no indicator
- **Mismatched worktrees**: shows `[📂 folder-name]` when terminal is wide enough to also fit the commit text; collapses to `[📂]` when space is tight
- A `│` pipe separates the worktree identity section from the status/commit tail

## Changes

- Added `mainWorktreeDir` tracking (first entry from `git worktree list`) to correctly identify the main repo regardless of which worktree `gt` is launched from
- Replaced full-path comparison with `isExpectedWorktreePath` that compares just the folder basename
- Removed path truncation helpers (`truncatePathTail`, `tailStringByWidth`, `truncateStringByWidth`) in favor of simple show-or-hide logic
- Added `truncateToWidth` for display-width-aware string truncation
- Cleaned up unused `go-runewidth` direct import, `math` import, and related constants

## Test plan

- [x] `TestIsExpectedWorktreePath` — validates branch-to-folder matching for simple names, slashed branches, mismatches, and edge cases
- [x] `TestTruncateToWidth` — validates width-aware truncation with ellipsis
- [x] Manual testing with real worktrees showing matching/mismatching folder names at various terminal widths