### PR TITLE
Support switching to remote branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ gt
 ```bash
 # In any git repository
 gt                    # Open interactive worktree manager
-gt feature-xyz        # Create worktree 'feature-xyz' from current branch and switch
+gt feature-xyz        # Reuse/create branch 'feature-xyz' and switch
 gt fix-bug main       # Create worktree 'fix-bug' from 'main' branch and switch
 ```
 
@@ -101,7 +101,7 @@ That's it. No configuration needed.
 ```bash
 gt my-feature
 ```
-Creates a new worktree from your current branch and switches to it immediately. Your original working directory stays untouched.
+Creates a worktree for `my-feature` and switches to it immediately. If `my-feature` already exists locally, that branch is reused. If a matching remote-tracking branch exists, or a matching remote branch can be discovered on exactly one remote or on the remote named by `checkout.defaultRemote`, `gt` creates a local tracking branch and uses that. Unfetched remote branches are fetched before creating the local branch. If no local or remote branch matches, `gt` creates a new branch from your current `HEAD`. Your original working directory stays untouched.
 
 ### 🎯 Interactive Management
 ```bash
@@ -142,10 +142,21 @@ my-project/
 ### Command Line
 ```bash
 gt                           # Open interactive worktree manager
-gt <name>                    # Create worktree from current branch and switch
+gt <name>                    # Reuse local/remote branch, or create from current HEAD
 gt <name> <branch>           # Create worktree from specified branch and switch
 gt -h, --help                # Show help
 ```
+
+### Branch Selection
+
+`gt <name>` follows the same remote-guessing behavior as `git switch <name>`:
+- If a local branch named `<name>` exists, `gt` creates a worktree for that branch.
+- If no local branch exists and a matching remote-tracking branch exists, or a matching branch is discovered on exactly one remote, `gt` creates a local branch tracking that remote branch and creates the worktree.
+- If the branch is discovered on the remote but has not been fetched yet, `gt` fetches that branch first.
+- If multiple remotes have the branch, set `checkout.defaultRemote` to choose one.
+- If no local or remote branch matches, `gt` creates a new branch from the current `HEAD`.
+
+`gt <name> <branch>` is explicit: it creates a new branch named `<name>` from `<branch>`.
 
 ### Interactive Mode (TUI)
 

--- a/main.go
+++ b/main.go
@@ -1399,22 +1399,114 @@ func refExists(repoPath, ref string) bool {
 }
 
 func localBranchExists(repoPath, branch string) bool {
-	return refExists(repoPath, branch)
+	return refExists(repoPath, fmt.Sprintf("refs/heads/%s", branch))
 }
 
-func remoteBranchExists(repoPath, branch string) bool {
-	// Fast path: check local tracking ref
-	if refExists(repoPath, fmt.Sprintf("refs/remotes/origin/%s", branch)) {
-		return true
+type remoteBranchMatch struct {
+	remote     string
+	ref        string
+	needsFetch bool
+}
+
+func getCheckoutDefaultRemote(repoPath string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
+	defer cancel()
+	output, err := runGitCmd(ctx, repoPath, "config", "--get", "checkout.defaultRemote")
+	if err != nil {
+		return ""
 	}
-	// Slow path: query remote (for unfetched branches)
+	return strings.TrimSpace(string(output))
+}
+
+func listRemotes(repoPath string) []string {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
+	defer cancel()
+	output, err := runGitCmd(ctx, repoPath, "remote")
+	if err != nil {
+		return nil
+	}
+	return strings.Fields(string(output))
+}
+
+func findRemoteBranch(repoPath, remote, branch string) (*remoteBranchMatch, bool) {
+	if refExists(repoPath, fmt.Sprintf("refs/remotes/%s/%s", remote, branch)) {
+		return &remoteBranchMatch{
+			remote: remote,
+			ref:    fmt.Sprintf("%s/%s", remote, branch),
+		}, true
+	}
+
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdSlowTimeout)
 	defer cancel()
-	output, err := runGitCmd(ctx, repoPath, "ls-remote", "--heads", "origin", branch)
-	return err == nil && len(strings.TrimSpace(string(output))) > 0
+	output, err := runGitCmd(ctx, repoPath, "ls-remote", "--heads", remote, fmt.Sprintf("refs/heads/%s", branch))
+	if err == nil && len(strings.TrimSpace(string(output))) > 0 {
+		return &remoteBranchMatch{
+			remote:     remote,
+			ref:        fmt.Sprintf("%s/%s", remote, branch),
+			needsFetch: true,
+		}, true
+	}
+
+	return nil, false
+}
+
+func fetchRemoteBranch(repoPath, remote, branch string) error {
+	refspec := fmt.Sprintf("+refs/heads/%s:refs/remotes/%s/%s", branch, remote, branch)
+	output, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, "fetch", remote, refspec)
+	if err != nil {
+		return fmt.Errorf("failed to fetch %s/%s: %s", remote, branch, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func resolveRemoteBranchForSwitch(repoPath, branch string) (*remoteBranchMatch, error) {
+	remotes := listRemotes(repoPath)
+	if len(remotes) == 0 {
+		return nil, nil
+	}
+
+	defaultRemote := getCheckoutDefaultRemote(repoPath)
+	if defaultRemote != "" {
+		for _, remote := range remotes {
+			if remote == defaultRemote {
+				match, ok := findRemoteBranch(repoPath, remote, branch)
+				if ok {
+					return match, nil
+				}
+			}
+		}
+	}
+
+	var matches []remoteBranchMatch
+	for _, remote := range remotes {
+		if match, ok := findRemoteBranch(repoPath, remote, branch); ok {
+			matches = append(matches, *match)
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	if len(matches) > 1 {
+		remoteNames := make([]string, 0, len(matches))
+		for _, match := range matches {
+			remoteNames = append(remoteNames, match.remote)
+		}
+		return nil, fmt.Errorf(
+			"branch %q exists on multiple remotes (%s); set checkout.defaultRemote or pass an explicit source branch",
+			branch,
+			strings.Join(remoteNames, ", "),
+		)
+	}
+
+	return &matches[0], nil
 }
 
 func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, config *Config) error {
+	if err := validateBranchName(worktreeName); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+
 	// Determine worktree directory
 	worktreeDir := defaultWorktreeDir
 	if config != nil && config.WorktreeDir != "" {
@@ -1465,6 +1557,10 @@ func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, confi
 }
 
 func createWorktree(repoPath, branch string, config *Config) error {
+	if err := validateBranchName(branch); err != nil {
+		return fmt.Errorf("invalid branch name: %w", err)
+	}
+
 	// Determine worktree directory
 	worktreeDir := defaultWorktreeDir
 	if config != nil && config.WorktreeDir != "" {
@@ -1501,19 +1597,31 @@ func createWorktree(repoPath, branch string, config *Config) error {
 
 	// Determine best strategy based on existing refs
 	var (
-		args         []string
-		remoteRef    = fmt.Sprintf("origin/%s", branch)
-		localExists  = localBranchExists(repoPath, branch)
-		remoteExists = remoteBranchExists(repoPath, branch)
+		args        []string
+		localExists = localBranchExists(repoPath, branch)
 	)
 
 	switch {
 	case localExists:
 		args = []string{"worktree", "add", worktreePath, branch}
-	case remoteExists:
-		args = []string{"worktree", "add", "--track", "-b", branch, worktreePath, remoteRef}
 	default:
-		args = []string{"worktree", "add", "-b", branch, worktreePath}
+		remoteMatch, err := resolveRemoteBranchForSwitch(repoPath, branch)
+		if err != nil {
+			return err
+		}
+		if remoteMatch != nil {
+			if remoteMatch.needsFetch {
+				if err := fetchRemoteBranch(repoPath, remoteMatch.remote, branch); err != nil {
+					return err
+				}
+			}
+			if !refExists(repoPath, fmt.Sprintf("refs/remotes/%s/%s", remoteMatch.remote, branch)) {
+				return fmt.Errorf("failed to resolve remote branch %s", remoteMatch.ref)
+			}
+			args = []string{"worktree", "add", "--track", "-b", branch, worktreePath, remoteMatch.ref}
+		} else {
+			args = []string{"worktree", "add", "-b", branch, worktreePath}
+		}
 	}
 
 	output, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
@@ -1947,7 +2055,7 @@ func printHelp() {
 
 USAGE:
     gt                           Open interactive worktree manager
-    gt <name>                    Create worktree from current branch and switch to it
+    gt <name>                    Create or reuse branch, then switch to its worktree
     gt <name> <branch>           Create worktree from specified branch and switch to it
     gt <name> -x <cmd>           Create worktree and execute command instead of shell
     gt --merge <branch>          Merge worktree branch into default and delete
@@ -1963,12 +2071,20 @@ OPTIONS:
 
 EXAMPLES:
     gt                           # Open TUI to manage worktrees
-    gt feature-xyz               # Create worktree 'feature-xyz' from current branch
+    gt feature-xyz               # Reuse local/remote branch, or create from current branch
     gt fix-bug main              # Create worktree 'fix-bug' from 'main' branch
     gt feature-xyz -x "code ."   # Create worktree and open in VS Code
     gt feature-xyz -x claude     # Create worktree and start Claude Code
     gt --merge feature-xyz       # Merge 'feature-xyz' into main (ff-only)
     gt --merge feature-xyz --squash  # Squash merge into main
+
+BRANCH CREATION:
+    gt <name> reuses an existing local branch when one exists. If no local branch
+    exists, gt follows git switch's remote guess behavior: it uses a matching
+    remote-tracking branch, or fetches a matching branch discovered on exactly
+    one remote or checkout.defaultRemote. If no local or remote branch matches,
+    gt creates a new branch from the current HEAD. gt <name> <branch> always
+    creates <name> from <branch>.
 
 SHELL COMPLETION:
     # Bash: Add to ~/.bashrc
@@ -2029,16 +2145,6 @@ CONFIGURATION:
     }
 `, version)
 	fmt.Print(help)
-}
-
-func getCurrentBranch(repoPath string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
-	cmd.Dir = repoPath
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(output)), nil
 }
 
 func getDefaultBranchWithContext(ctx context.Context, repoPath string) string {
@@ -2273,25 +2379,12 @@ func main() {
 			config = &Config{}
 		}
 
-		// Determine source branch
-		if sourceBranch == "" {
-			// Use current branch
-			sourceBranch, err = getCurrentBranch(repoPath)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error getting current branch: %v\n", err)
-				os.Exit(1)
-			}
-		}
-
 		// Create the worktree
-		fmt.Printf("Creating worktree '%s' from branch '%s'...\n", worktreeName, sourceBranch)
-
-		// First check if we need to create from an existing branch or create new
-		if sourceBranch != worktreeName {
-			// Create worktree from existing branch
+		if sourceBranch != "" {
+			fmt.Printf("Creating worktree '%s' from branch '%s'...\n", worktreeName, sourceBranch)
 			err = createWorktreeFromBranch(repoPath, worktreeName, sourceBranch, config)
 		} else {
-			// Create new branch with worktree
+			fmt.Printf("Creating worktree '%s'...\n", worktreeName)
 			err = createWorktree(repoPath, worktreeName, config)
 		}
 

--- a/main.go
+++ b/main.go
@@ -1408,6 +1408,9 @@ type remoteBranchMatch struct {
 	needsFetch bool
 }
 
+// getCheckoutDefaultRemote returns the value of the `checkout.defaultRemote`
+// git config option, or "" if unset. A read error is treated as "unset" so
+// callers fall back to the multi-remote ambiguity check.
 func getCheckoutDefaultRemote(repoPath string) string {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	defer cancel()
@@ -1418,6 +1421,8 @@ func getCheckoutDefaultRemote(repoPath string) string {
 	return strings.TrimSpace(string(output))
 }
 
+// listRemotes returns the configured remote names. A read error is treated
+// as "no remotes" so callers skip remote discovery and create a fresh branch.
 func listRemotes(repoPath string) []string {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	defer cancel()
@@ -1459,6 +1464,10 @@ func fetchRemoteBranch(repoPath, remote, branch string) error {
 	return nil
 }
 
+// resolveRemoteBranchForSwitch implements the same remote-guessing behavior as
+// `git switch <name>` (a.k.a. --guess-remote): when `checkout.defaultRemote` is
+// set and the branch exists on that remote, that one wins; otherwise the branch
+// must exist on exactly one remote. Anything ambiguous returns an error.
 func resolveRemoteBranchForSwitch(repoPath, branch string) (*remoteBranchMatch, error) {
 	remotes := listRemotes(repoPath)
 	if len(remotes) == 0 {
@@ -1599,26 +1608,33 @@ func createWorktree(repoPath, branch string, config *Config) error {
 	var (
 		args        []string
 		localExists = localBranchExists(repoPath, branch)
+		remoteMatch *remoteBranchMatch
 	)
 
 	switch {
 	case localExists:
 		args = []string{"worktree", "add", worktreePath, branch}
 	default:
-		remoteMatch, err := resolveRemoteBranchForSwitch(repoPath, branch)
+		match, err := resolveRemoteBranchForSwitch(repoPath, branch)
 		if err != nil {
 			return err
 		}
+		remoteMatch = match
 		if remoteMatch != nil {
 			if remoteMatch.needsFetch {
 				if err := fetchRemoteBranch(repoPath, remoteMatch.remote, branch); err != nil {
 					return err
 				}
 			}
-			if !refExists(repoPath, fmt.Sprintf("refs/remotes/%s/%s", remoteMatch.remote, branch)) {
+			fullRef := fmt.Sprintf("refs/remotes/%s/%s", remoteMatch.remote, branch)
+			if !refExists(repoPath, fullRef) {
 				return fmt.Errorf("failed to resolve remote branch %s", remoteMatch.ref)
 			}
-			args = []string{"worktree", "add", "--track", "-b", branch, worktreePath, remoteMatch.ref}
+			// Use --no-track and set upstream explicitly afterwards. `--track`
+			// rejects start points that aren't covered by the remote's
+			// configured fetch refspec (e.g. single-branch clones), which would
+			// fail even though we just fetched the ref.
+			args = []string{"worktree", "add", "--no-track", "-b", branch, worktreePath, fullRef}
 		} else {
 			args = []string{"worktree", "add", "-b", branch, worktreePath}
 		}
@@ -1627,6 +1643,22 @@ func createWorktree(repoPath, branch string, config *Config) error {
 	output, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
 	if err != nil {
 		return fmt.Errorf("failed to create worktree: %s", strings.TrimSpace(string(output)))
+	}
+
+	// Point the new branch's upstream at the remote branch we used. Done by
+	// writing config directly (not via `branch --set-upstream-to`) so it works
+	// in single-branch / restricted-refspec clones, where git refuses to track
+	// a ref outside the configured fetch refspec.
+	if remoteMatch != nil {
+		remoteKey := fmt.Sprintf("branch.%s.remote", branch)
+		mergeKey := fmt.Sprintf("branch.%s.merge", branch)
+		mergeRef := fmt.Sprintf("refs/heads/%s", branch)
+		if out, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "config", remoteKey, remoteMatch.remote); err != nil {
+			return fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
+		}
+		if out, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "config", mergeKey, mergeRef); err != nil {
+			return fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
+		}
 	}
 
 	return nil

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -61,6 +61,72 @@ func TestGTRunCreatesWorktreeAndUpdatesExcludes(t *testing.T) {
 	}
 }
 
+func TestGTRunCreatesWorktreeFromRemoteBranch(t *testing.T) {
+	seedPath := initRepo(t)
+	binaryPath := buildBinary(t)
+
+	// Seed a bare origin with only the default branch.
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	defaultBranch := strings.TrimSpace(string(runGit(t, seedPath, "rev-parse", "--abbrev-ref", "HEAD")))
+	runGit(t, seedPath, "init", "--bare", remotePath)
+	runGit(t, seedPath, "remote", "add", "origin", remotePath)
+	runGit(t, seedPath, "push", "-u", "origin", defaultBranch)
+	runGit(t, remotePath, "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch)
+
+	// This is the repo where the user will run gt. It is cloned before the
+	// remote-only branch exists, so it cannot already know about that branch.
+	targetParent := t.TempDir()
+	targetPath := filepath.Join(targetParent, "target")
+	runGit(t, targetParent, "clone", remotePath, targetPath)
+
+	// Simulate someone else creating and pushing the branch on the remote.
+	publisherParent := t.TempDir()
+	publisherPath := filepath.Join(publisherParent, "publisher")
+	runGit(t, publisherParent, "clone", remotePath, publisherPath)
+	runGit(t, publisherPath, "checkout", "-b", "remote-feature")
+	remoteFile := filepath.Join(publisherPath, "remote.txt")
+	if err := os.WriteFile(remoteFile, []byte("from remote"), 0644); err != nil {
+		t.Fatalf("write remote file: %v", err)
+	}
+	runGit(t, publisherPath, "add", "remote.txt")
+	runGit(t, publisherPath, "-c", "user.name=Test", "-c", "user.email=test@example.com",
+		"commit", "-m", "remote feature")
+	runGit(t, publisherPath, "push", "origin", "remote-feature")
+
+	// Prove the target clone has neither a local branch nor a remote-tracking
+	// branch before gt runs. gt must discover and fetch the remote branch.
+	localBranch := strings.TrimSpace(string(runGit(t, targetPath, "branch", "--list", "remote-feature")))
+	if localBranch != "" {
+		t.Fatalf("target clone unexpectedly has local branch: %q", localBranch)
+	}
+	remoteTrackingBranch := strings.TrimSpace(string(runGit(t, targetPath, "branch", "-r", "--list", "origin/remote-feature")))
+	if remoteTrackingBranch != "" {
+		t.Fatalf("target clone unexpectedly has remote-tracking branch: %q", remoteTrackingBranch)
+	}
+
+	// Running gt with just the branch name should create a worktree from the
+	// remote branch, not create a new same-named branch from the current HEAD.
+	cmd := exec.Command(binaryPath, "-x", "true", "remote-feature")
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	worktreePath := filepath.Join(targetPath, defaultWorktreeDir, "remote-feature")
+	if _, err := os.Stat(filepath.Join(worktreePath, "remote.txt")); err != nil {
+		t.Fatalf("expected worktree to contain remote branch file: %v", err)
+	}
+
+	// The local branch should track the remote branch, matching git switch's
+	// remote-guess behavior.
+	upstream := strings.TrimSpace(string(runGit(t, targetPath,
+		"rev-parse", "--abbrev-ref", "--symbolic-full-name", "remote-feature@{upstream}")))
+	if upstream != "origin/remote-feature" {
+		t.Fatalf("upstream = %q, want origin/remote-feature", upstream)
+	}
+}
+
 func TestGTCreateWorktreeFromSourceBranch(t *testing.T) {
 	repoPath := initRepo(t)
 	binaryPath := buildBinary(t)

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -127,6 +127,192 @@ func TestGTRunCreatesWorktreeFromRemoteBranch(t *testing.T) {
 	}
 }
 
+// publishBranch creates `branchName` in publisher, commits a file, and pushes
+// it to every remote configured in publisher.
+func publishBranch(t *testing.T, publisherPath, branchName, fileName, fileContents string, remotes ...string) {
+	t.Helper()
+	runGit(t, publisherPath, "checkout", "-b", branchName)
+	if err := os.WriteFile(filepath.Join(publisherPath, fileName), []byte(fileContents), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	runGit(t, publisherPath, "add", fileName)
+	runGit(t, publisherPath, "-c", "user.name=Test", "-c", "user.email=test@example.com",
+		"commit", "-m", "publish "+branchName)
+	for _, remote := range remotes {
+		runGit(t, publisherPath, "push", remote, branchName)
+	}
+	runGit(t, publisherPath, "checkout", "master")
+}
+
+// initBareWithSeed sets up a bare origin populated by `seedPath` and returns the
+// bare repo path with HEAD pointing at the default branch.
+func initBareWithSeed(t *testing.T, seedPath string) string {
+	t.Helper()
+	remotePath := filepath.Join(t.TempDir(), "origin.git")
+	defaultBranch := strings.TrimSpace(string(runGit(t, seedPath, "rev-parse", "--abbrev-ref", "HEAD")))
+	runGit(t, seedPath, "init", "--bare", remotePath)
+	runGit(t, seedPath, "remote", "add", "origin", remotePath)
+	runGit(t, seedPath, "push", "-u", "origin", defaultBranch)
+	runGit(t, remotePath, "symbolic-ref", "HEAD", "refs/heads/"+defaultBranch)
+	return remotePath
+}
+
+// TestGTRunSingleBranchCloneFetchesRemoteBranch verifies the case that broke
+// before: a single-branch clone whose configured fetch refspec does not cover
+// the requested branch. gt must explicitly fetch the branch and set up
+// upstream config directly, bypassing git's refspec-aware tracking checks.
+func TestGTRunSingleBranchCloneFetchesRemoteBranch(t *testing.T) {
+	seedPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	remotePath := initBareWithSeed(t, seedPath)
+
+	publisherParent := t.TempDir()
+	publisherPath := filepath.Join(publisherParent, "publisher")
+	runGit(t, publisherParent, "clone", remotePath, publisherPath)
+	publishBranch(t, publisherPath, "remote-feature", "remote.txt", "from remote", "origin")
+
+	// Single-branch clone restricts remote.origin.fetch to master only.
+	targetParent := t.TempDir()
+	targetPath := filepath.Join(targetParent, "target")
+	runGit(t, targetParent, "clone", "--single-branch", "-b", "master", remotePath, targetPath)
+
+	fetchSpec := strings.TrimSpace(string(runGit(t, targetPath, "config", "--get-all", "remote.origin.fetch")))
+	if strings.Contains(fetchSpec, "remote-feature") || strings.Contains(fetchSpec, "*") {
+		t.Fatalf("expected restricted fetch refspec, got %q", fetchSpec)
+	}
+
+	cmd := exec.Command(binaryPath, "-x", "true", "remote-feature")
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	worktreePath := filepath.Join(targetPath, defaultWorktreeDir, "remote-feature")
+	if _, err := os.Stat(filepath.Join(worktreePath, "remote.txt")); err != nil {
+		t.Fatalf("expected worktree to contain remote branch file: %v", err)
+	}
+
+	// `@{upstream}` rejects refs outside the configured refspec in single-branch
+	// clones, even when the underlying config is valid. Check the config keys
+	// directly, which is what gt writes and what `git pull` consults.
+	remote := strings.TrimSpace(string(runGit(t, targetPath, "config", "--get", "branch.remote-feature.remote")))
+	merge := strings.TrimSpace(string(runGit(t, targetPath, "config", "--get", "branch.remote-feature.merge")))
+	if remote != "origin" || merge != "refs/heads/remote-feature" {
+		t.Fatalf("upstream config = (%q, %q), want (origin, refs/heads/remote-feature)", remote, merge)
+	}
+}
+
+// TestGTRunMultiRemoteConflictErrors verifies that when the same branch lives
+// on multiple remotes and no checkout.defaultRemote is set, gt refuses to
+// guess and returns a helpful error.
+func TestGTRunMultiRemoteConflictErrors(t *testing.T) {
+	seedPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	remoteAPath := initBareWithSeed(t, seedPath)
+	remoteBPath := filepath.Join(t.TempDir(), "originB.git")
+	runGit(t, seedPath, "init", "--bare", remoteBPath)
+	runGit(t, seedPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, seedPath, "push", "originB", "master")
+
+	publisherParent := t.TempDir()
+	publisherPath := filepath.Join(publisherParent, "publisher")
+	runGit(t, publisherParent, "clone", remoteAPath, publisherPath)
+	runGit(t, publisherPath, "remote", "add", "originB", remoteBPath)
+	publishBranch(t, publisherPath, "shared", "shared.txt", "x", "origin", "originB")
+
+	targetParent := t.TempDir()
+	targetPath := filepath.Join(targetParent, "target")
+	runGit(t, targetParent, "clone", remoteAPath, targetPath)
+	runGit(t, targetPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, targetPath, "fetch", "originB")
+
+	cmd := exec.Command(binaryPath, "-x", "true", "shared")
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gt to error on multi-remote ambiguity, got success:\n%s", output)
+	}
+	if !strings.Contains(string(output), "multiple remotes") {
+		t.Fatalf("expected multi-remote error message, got:\n%s", output)
+	}
+}
+
+// TestGTRunDefaultRemoteWins verifies that checkout.defaultRemote disambiguates
+// when the same branch lives on multiple remotes.
+func TestGTRunDefaultRemoteWins(t *testing.T) {
+	seedPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	remoteAPath := initBareWithSeed(t, seedPath)
+	remoteBPath := filepath.Join(t.TempDir(), "originB.git")
+	runGit(t, seedPath, "init", "--bare", remoteBPath)
+	runGit(t, seedPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, seedPath, "push", "originB", "master")
+
+	publisherParent := t.TempDir()
+	publisherPath := filepath.Join(publisherParent, "publisher")
+	runGit(t, publisherParent, "clone", remoteAPath, publisherPath)
+	runGit(t, publisherPath, "remote", "add", "originB", remoteBPath)
+	publishBranch(t, publisherPath, "shared", "shared.txt", "x", "origin", "originB")
+
+	targetParent := t.TempDir()
+	targetPath := filepath.Join(targetParent, "target")
+	runGit(t, targetParent, "clone", remoteAPath, targetPath)
+	runGit(t, targetPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, targetPath, "fetch", "originB")
+	runGit(t, targetPath, "config", "checkout.defaultRemote", "originB")
+
+	cmd := exec.Command(binaryPath, "-x", "true", "shared")
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	remote := strings.TrimSpace(string(runGit(t, targetPath, "config", "--get", "branch.shared.remote")))
+	if remote != "originB" {
+		t.Fatalf("branch.shared.remote = %q, want originB", remote)
+	}
+}
+
+// TestGTRunDefaultRemoteFallthrough verifies that when checkout.defaultRemote
+// is set but the branch is not on that remote, gt still finds the branch on
+// the other remote where it actually exists.
+func TestGTRunDefaultRemoteFallthrough(t *testing.T) {
+	seedPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	remoteAPath := initBareWithSeed(t, seedPath)
+	remoteBPath := filepath.Join(t.TempDir(), "originB.git")
+	runGit(t, seedPath, "init", "--bare", remoteBPath)
+	runGit(t, seedPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, seedPath, "push", "originB", "master")
+
+	publisherParent := t.TempDir()
+	publisherPath := filepath.Join(publisherParent, "publisher")
+	runGit(t, publisherParent, "clone", remoteAPath, publisherPath)
+	runGit(t, publisherPath, "remote", "add", "originB", remoteBPath)
+	publishBranch(t, publisherPath, "b-only", "b.txt", "x", "originB")
+
+	targetParent := t.TempDir()
+	targetPath := filepath.Join(targetParent, "target")
+	runGit(t, targetParent, "clone", remoteAPath, targetPath)
+	runGit(t, targetPath, "remote", "add", "originB", remoteBPath)
+	runGit(t, targetPath, "fetch", "originB")
+	runGit(t, targetPath, "config", "checkout.defaultRemote", "origin")
+
+	cmd := exec.Command(binaryPath, "-x", "true", "b-only")
+	cmd.Dir = targetPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	remote := strings.TrimSpace(string(runGit(t, targetPath, "config", "--get", "branch.b-only.remote")))
+	if remote != "originB" {
+		t.Fatalf("branch.b-only.remote = %q, want originB (fallthrough)", remote)
+	}
+}
+
 func TestGTCreateWorktreeFromSourceBranch(t *testing.T) {
 	repoPath := initRepo(t)
 	binaryPath := buildBinary(t)

--- a/test_helpers_test.go
+++ b/test_helpers_test.go
@@ -11,7 +11,11 @@ import (
 func runGit(t *testing.T, repoPath string, args ...string) []byte {
 	t.Helper()
 
-	cmd := exec.Command("git", args...)
+	gitArgs := append([]string{
+		"-c", "commit.gpgsign=false",
+		"-c", "tag.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", gitArgs...)
 	cmd.Dir = repoPath
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -25,7 +29,7 @@ func initRepo(t *testing.T) string {
 	t.Helper()
 
 	repoPath := t.TempDir()
-	runGit(t, repoPath, "init")
+	runGit(t, repoPath, "init", "--initial-branch=master")
 
 	readmePath := filepath.Join(repoPath, "README.md")
 	if err := os.WriteFile(readmePath, []byte("test"), 0644); err != nil {


### PR DESCRIPTION
Adds git-switch-like remote branch handling for gt <branch>.

- Reuses local branches, otherwise creates tracking branches from matching remotes
- Covers unfetched origin branches with an e2e test
- Clarifies branch selection behavior in docs
 
Checks: just check