### PR TITLE
Fix relative worktree dir from linked worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,15 @@ Configuration file: `~/.config/gt/config.json`
 
 ```json
 {
-  "worktree_dir": ".worktrees",  // Where to store worktrees (relative or absolute)
+  "worktree_dir": ".worktrees",  // Worktree storage path (relative or absolute)
   "shell": "fish"                 // Override shell (default: $SHELL)
 }
 ```
+
+Relative `worktree_dir` values are resolved from the main worktree in normal
+non-bare repositories with a real `.git/` directory. If `gt` cannot identify
+that typical layout, it falls back to resolving them from the current Git
+top-level directory.
 
 ### Environment Variables
 
@@ -235,7 +240,7 @@ Git worktrees let you have multiple working directories for the same repository.
 A: `gt` is to `git worktree` what `tig` is to `git log`. It makes the powerful feature actually pleasant to use.
 
 **Q: Where are my worktrees stored?**
-A: By default in `.worktrees/` within your repo. This is configurable and automatically added to `.git/info/exclude`.
+A: By default in `.worktrees/` within your main worktree. This is configurable and automatically added to `.git/info/exclude` when the directory is inside the repo.
 
 **Q: Can I use my existing worktrees?**
 A: Yes! `gt` shows all worktrees, regardless of where they were created.

--- a/main.go
+++ b/main.go
@@ -446,6 +446,24 @@ func getMainWorktreePath(repoPath string) (string, bool) {
 		return "", false
 	}
 
+	// A separate Git directory ending in .git is indistinguishable from a
+	// main worktree to `git worktree list`, which reports its parent as the
+	// first worktree. Do not accept a path that only contains Git metadata.
+	entries, err := os.ReadDir(mainWorktreePath)
+	if err != nil {
+		return "", false
+	}
+	containsWorktreeFiles := false
+	for _, entry := range entries {
+		if entry.Name() != ".git" {
+			containsWorktreeFiles = true
+			break
+		}
+	}
+	if !containsWorktreeFiles {
+		return "", false
+	}
+
 	resolvedRootGitDir, err := filepath.EvalSymlinks(rootGitDir)
 	if err != nil {
 		return "", false

--- a/main.go
+++ b/main.go
@@ -398,16 +398,54 @@ func getMainWorktreePath(repoPath string) (string, bool) {
 		return "", false
 	}
 
+	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--path-format=absolute", "--git-dir")
+	if err != nil {
+		return "", false
+	}
+	gitDir := filepath.Clean(strings.TrimSpace(string(output)))
+	resolvedGitDir, err := filepath.EvalSymlinks(gitDir)
+	if err != nil {
+		return "", false
+	}
+	resolvedCommonDir, err := filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return "", false
+	}
+	if resolvedGitDir == resolvedCommonDir {
+		return repoPath, true
+	}
+
+	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "worktree", "list", "--porcelain")
+	if err != nil {
+		return "", false
+	}
+
+	var listedMainWorktreePath string
+	for _, line := range strings.Split(string(output), "\n") {
+		if path, found := strings.CutPrefix(line, "worktree "); found {
+			listedMainWorktreePath = filepath.Clean(path)
+			break
+		}
+	}
+	if listedMainWorktreePath == "" {
+		return "", false
+	}
+
 	mainWorktreePath := filepath.Dir(commonDir)
+	resolvedMainWorktreePath, err := filepath.EvalSymlinks(mainWorktreePath)
+	if err != nil {
+		return "", false
+	}
+	resolvedListedMainWorktreePath, err := filepath.EvalSymlinks(listedMainWorktreePath)
+	if err != nil || resolvedMainWorktreePath != resolvedListedMainWorktreePath {
+		return "", false
+	}
+
 	rootGitDir := filepath.Join(mainWorktreePath, ".git")
 	if info, err := os.Stat(rootGitDir); err != nil || !info.IsDir() {
 		return "", false
 	}
 
-	resolvedCommonDir, err := filepath.EvalSymlinks(commonDir)
-	if err != nil {
-		return "", false
-	}
 	resolvedRootGitDir, err := filepath.EvalSymlinks(rootGitDir)
 	if err != nil {
 		return "", false
@@ -452,6 +490,9 @@ func relPathWithin(basePath, targetPath string) (string, bool) {
 
 func ensureWorktreeDir(repoPath string, config *Config) (string, error) {
 	worktreeDir, baseRepoPath := resolveWorktreeDir(repoPath, config)
+	if filepath.Clean(worktreeDir) == filepath.Clean(baseRepoPath) {
+		return "", fmt.Errorf("worktree directory must not be the repository root")
+	}
 
 	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
 		return "", err

--- a/main.go
+++ b/main.go
@@ -370,109 +370,38 @@ func getCurrentRepoPath() (string, error) {
 }
 
 func getMainWorktreePath(repoPath string) (string, bool) {
-	output, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--is-bare-repository")
-	if err != nil || strings.TrimSpace(string(output)) == "true" {
-		return "", false
-	}
-
-	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--is-inside-work-tree")
-	if err != nil || strings.TrimSpace(string(output)) != "true" {
-		return "", false
-	}
-
-	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--show-superproject-working-tree")
-	if err != nil || strings.TrimSpace(string(output)) != "" {
-		return "", false
-	}
-
-	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	output, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "worktree", "list", "--porcelain")
 	if err != nil {
 		return "", false
 	}
 
-	commonDir := filepath.Clean(strings.TrimSpace(string(output)))
-	if filepath.Base(commonDir) != ".git" {
-		return "", false
-	}
-	if info, err := os.Stat(commonDir); err != nil || !info.IsDir() {
-		return "", false
-	}
-
-	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--path-format=absolute", "--git-dir")
-	if err != nil {
-		return "", false
-	}
-	gitDir := filepath.Clean(strings.TrimSpace(string(output)))
-	resolvedGitDir, err := filepath.EvalSymlinks(gitDir)
-	if err != nil {
-		return "", false
-	}
-	resolvedCommonDir, err := filepath.EvalSymlinks(commonDir)
-	if err != nil {
-		return "", false
-	}
-	if resolvedGitDir == resolvedCommonDir {
-		return repoPath, true
-	}
-
-	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "worktree", "list", "--porcelain")
-	if err != nil {
-		return "", false
-	}
-
-	var listedMainWorktreePath string
+	var mainWorktreePath string
 	for _, line := range strings.Split(string(output), "\n") {
 		if path, found := strings.CutPrefix(line, "worktree "); found {
-			listedMainWorktreePath = filepath.Clean(path)
+			mainWorktreePath = filepath.Clean(path)
 			break
 		}
 	}
-	if listedMainWorktreePath == "" {
+	if mainWorktreePath == "" {
 		return "", false
 	}
 
-	mainWorktreePath := filepath.Dir(commonDir)
-	resolvedMainWorktreePath, err := filepath.EvalSymlinks(mainWorktreePath)
-	if err != nil {
+	// Only recognize the conventional layout: a non-empty checkout with its
+	// Git directory at <worktree>/.git. Ambiguous layouts fall back to the
+	// current Git top-level.
+	if info, err := os.Stat(filepath.Join(mainWorktreePath, ".git")); err != nil || !info.IsDir() {
 		return "", false
 	}
-	resolvedListedMainWorktreePath, err := filepath.EvalSymlinks(listedMainWorktreePath)
-	if err != nil || resolvedMainWorktreePath != resolvedListedMainWorktreePath {
-		return "", false
-	}
-
-	rootGitDir := filepath.Join(mainWorktreePath, ".git")
-	if info, err := os.Stat(rootGitDir); err != nil || !info.IsDir() {
-		return "", false
-	}
-
-	// A separate Git directory ending in .git is indistinguishable from a
-	// main worktree to `git worktree list`, which reports its parent as the
-	// first worktree. Do not accept a path that only contains Git metadata.
 	entries, err := os.ReadDir(mainWorktreePath)
 	if err != nil {
 		return "", false
 	}
-	containsWorktreeFiles := false
 	for _, entry := range entries {
 		if entry.Name() != ".git" {
-			containsWorktreeFiles = true
-			break
+			return mainWorktreePath, true
 		}
 	}
-	if !containsWorktreeFiles {
-		return "", false
-	}
-
-	resolvedRootGitDir, err := filepath.EvalSymlinks(rootGitDir)
-	if err != nil {
-		return "", false
-	}
-	if resolvedCommonDir != resolvedRootGitDir {
-		return "", false
-	}
-
-	return mainWorktreePath, true
+	return "", false
 }
 
 func configuredWorktreeDir(config *Config) string {

--- a/main.go
+++ b/main.go
@@ -369,6 +369,112 @@ func getCurrentRepoPath() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+func getMainWorktreePath(repoPath string) (string, bool) {
+	output, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--is-bare-repository")
+	if err != nil || strings.TrimSpace(string(output)) == "true" {
+		return "", false
+	}
+
+	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--is-inside-work-tree")
+	if err != nil || strings.TrimSpace(string(output)) != "true" {
+		return "", false
+	}
+
+	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--show-superproject-working-tree")
+	if err != nil || strings.TrimSpace(string(output)) != "" {
+		return "", false
+	}
+
+	output, err = runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "rev-parse", "--path-format=absolute", "--git-common-dir")
+	if err != nil {
+		return "", false
+	}
+
+	commonDir := filepath.Clean(strings.TrimSpace(string(output)))
+	if filepath.Base(commonDir) != ".git" {
+		return "", false
+	}
+	if info, err := os.Stat(commonDir); err != nil || !info.IsDir() {
+		return "", false
+	}
+
+	mainWorktreePath := filepath.Dir(commonDir)
+	rootGitDir := filepath.Join(mainWorktreePath, ".git")
+	if info, err := os.Stat(rootGitDir); err != nil || !info.IsDir() {
+		return "", false
+	}
+
+	resolvedCommonDir, err := filepath.EvalSymlinks(commonDir)
+	if err != nil {
+		return "", false
+	}
+	resolvedRootGitDir, err := filepath.EvalSymlinks(rootGitDir)
+	if err != nil {
+		return "", false
+	}
+	if resolvedCommonDir != resolvedRootGitDir {
+		return "", false
+	}
+
+	return mainWorktreePath, true
+}
+
+func configuredWorktreeDir(config *Config) string {
+	if config != nil && config.WorktreeDir != "" {
+		return config.WorktreeDir
+	}
+	return defaultWorktreeDir
+}
+
+func resolveWorktreeDir(repoPath string, config *Config) (worktreeDir, baseRepoPath string) {
+	worktreeDir = configuredWorktreeDir(config)
+	if filepath.IsAbs(worktreeDir) {
+		return filepath.Clean(worktreeDir), repoPath
+	}
+
+	baseRepoPath = repoPath
+	if mainWorktreePath, ok := getMainWorktreePath(repoPath); ok {
+		baseRepoPath = mainWorktreePath
+	}
+	return filepath.Join(baseRepoPath, worktreeDir), baseRepoPath
+}
+
+func relPathWithin(basePath, targetPath string) (string, bool) {
+	relPath, err := filepath.Rel(basePath, targetPath)
+	if err != nil || relPath == "" || relPath == "." || filepath.IsAbs(relPath) {
+		return "", false
+	}
+	if relPath == ".." || strings.HasPrefix(relPath, ".."+string(filepath.Separator)) {
+		return "", false
+	}
+	return relPath, true
+}
+
+func ensureWorktreeDir(repoPath string, config *Config) (string, error) {
+	worktreeDir, baseRepoPath := resolveWorktreeDir(repoPath, config)
+
+	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+		return "", err
+	}
+
+	if relPath, ok := relPathWithin(baseRepoPath, worktreeDir); ok {
+		if err := ensureNoTrackedFiles(baseRepoPath, relPath); err != nil {
+			return "", err
+		}
+		if err := ensureGitExcludeEntry(baseRepoPath, relPath); err != nil {
+			// Don't fail the worktree creation if we can't update git excludes.
+			fmt.Fprintf(os.Stderr, "Warning: Could not update git excludes: %v\n", err)
+		}
+	}
+
+	return worktreeDir, nil
+}
+
+func worktreePathForBranch(repoPath, branch string, config *Config) string {
+	worktreeDir, _ := resolveWorktreeDir(repoPath, config)
+	return filepath.Join(worktreeDir, strings.ReplaceAll(branch, "/", "-"))
+}
+
 // runGitCmd executes a git command with context support for cancellation.
 func runGitCmd(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
@@ -1560,35 +1666,9 @@ func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, confi
 		return fmt.Errorf("invalid branch name: %w", err)
 	}
 
-	// Determine worktree directory
-	worktreeDir := defaultWorktreeDir
-	if config != nil && config.WorktreeDir != "" {
-		worktreeDir = config.WorktreeDir
-	}
-
-	// Handle absolute vs relative paths
-	if !filepath.IsAbs(worktreeDir) {
-		worktreeDir = filepath.Join(repoPath, worktreeDir)
-	}
-
-	// Create worktree directory if it doesn't exist
-	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+	worktreeDir, err := ensureWorktreeDir(repoPath, config)
+	if err != nil {
 		return err
-	}
-
-	// Add worktree directory to git excludes if it's within the repo
-	if strings.HasPrefix(worktreeDir, repoPath) {
-		relPath, _ := filepath.Rel(repoPath, worktreeDir)
-		if relPath != "" && !strings.HasPrefix(relPath, "..") {
-			if err := ensureNoTrackedFiles(repoPath, relPath); err != nil {
-				return err
-			}
-			if err := ensureGitExcludeEntry(repoPath, relPath); err != nil {
-				// Don't fail the worktree creation if we can't update git excludes
-				// Just continue with a warning
-				fmt.Fprintf(os.Stderr, "Warning: Could not update git excludes: %v\n", err)
-			}
-		}
 	}
 
 	// Generate worktree path
@@ -1596,7 +1676,7 @@ func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, confi
 
 	// Create worktree with new branch from source branch
 	args := []string{"worktree", "add", "-b", worktreeName, worktreePath, sourceBranch}
-	_, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
+	_, err = runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
 	if err != nil {
 		// If branch already exists, try without -b flag
 		args = []string{"worktree", "add", worktreePath, worktreeName}
@@ -1614,35 +1694,9 @@ func createWorktree(repoPath, branch string, config *Config) error {
 		return fmt.Errorf("invalid branch name: %w", err)
 	}
 
-	// Determine worktree directory
-	worktreeDir := defaultWorktreeDir
-	if config != nil && config.WorktreeDir != "" {
-		worktreeDir = config.WorktreeDir
-	}
-
-	// Handle absolute vs relative paths
-	if !filepath.IsAbs(worktreeDir) {
-		worktreeDir = filepath.Join(repoPath, worktreeDir)
-	}
-
-	// Create worktree directory if it doesn't exist
-	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+	worktreeDir, err := ensureWorktreeDir(repoPath, config)
+	if err != nil {
 		return err
-	}
-
-	// Add worktree directory to git excludes if it's within the repo
-	if strings.HasPrefix(worktreeDir, repoPath) {
-		relPath, _ := filepath.Rel(repoPath, worktreeDir)
-		if relPath != "" && !strings.HasPrefix(relPath, "..") {
-			if err := ensureNoTrackedFiles(repoPath, relPath); err != nil {
-				return err
-			}
-			if err := ensureGitExcludeEntry(repoPath, relPath); err != nil {
-				// Don't fail the worktree creation if we can't update git excludes
-				// Just continue with a warning
-				fmt.Fprintf(os.Stderr, "Warning: Could not update git excludes: %v\n", err)
-			}
-		}
 	}
 
 	// Generate worktree path
@@ -2239,6 +2293,8 @@ CONFIGURATION:
 
     Options:
     - worktree_dir: Directory for worktrees (default: .worktrees)
+                    Relative paths use the main worktree in normal repos
+                    Falls back to the current Git top-level otherwise
                     Use absolute path to place worktrees outside repo
                     Use "../" prefix to place worktrees as siblings
     - shell: Shell to use when switching (default: $SHELL or /bin/bash)
@@ -2511,15 +2567,7 @@ func main() {
 			os.Exit(1)
 		}
 
-		// Determine worktree path
-		worktreeDir := defaultWorktreeDir
-		if config != nil && config.WorktreeDir != "" {
-			worktreeDir = config.WorktreeDir
-		}
-		if !filepath.IsAbs(worktreeDir) {
-			worktreeDir = filepath.Join(repoPath, worktreeDir)
-		}
-		worktreePath := filepath.Join(worktreeDir, strings.ReplaceAll(worktreeName, "/", "-"))
+		worktreePath := worktreePathForBranch(repoPath, worktreeName, config)
 
 		// Run post-create hook if configured
 		if err := runPostCreateHook(worktreePath, config); err != nil {

--- a/main.go
+++ b/main.go
@@ -511,11 +511,6 @@ func ensureWorktreeDir(repoPath string, config *Config) (string, error) {
 	return worktreeDir, nil
 }
 
-func worktreePathForBranch(repoPath, branch string, config *Config) string {
-	worktreeDir, _ := resolveWorktreeDir(repoPath, config)
-	return filepath.Join(worktreeDir, strings.ReplaceAll(branch, "/", "-"))
-}
-
 // runGitCmd executes a git command with context support for cancellation.
 func runGitCmd(ctx context.Context, dir string, args ...string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, "git", args...)
@@ -934,7 +929,7 @@ func createWorktreeCmd(repoPath, branch string, config *Config) tea.Cmd {
 		cfg = &copy
 	}
 	return func() tea.Msg {
-		err := createWorktree(repoPath, branch, cfg)
+		_, err := createWorktree(repoPath, branch, cfg)
 		return worktreeCreatedMsg{
 			branch: branch,
 			err:    err,
@@ -1702,14 +1697,14 @@ func resolveRemoteBranchForSwitch(repoPath, branch string) (*remoteBranchMatch, 
 	return &matches[0], nil
 }
 
-func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, config *Config) error {
+func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, config *Config) (string, error) {
 	if err := validateBranchName(worktreeName); err != nil {
-		return fmt.Errorf("invalid branch name: %w", err)
+		return "", fmt.Errorf("invalid branch name: %w", err)
 	}
 
 	worktreeDir, err := ensureWorktreeDir(repoPath, config)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Generate worktree path
@@ -1723,21 +1718,21 @@ func createWorktreeFromBranch(repoPath, worktreeName, sourceBranch string, confi
 		args = []string{"worktree", "add", worktreePath, worktreeName}
 		output, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
 		if err != nil {
-			return fmt.Errorf("failed to create worktree: %s", strings.TrimSpace(string(output)))
+			return "", fmt.Errorf("failed to create worktree: %s", strings.TrimSpace(string(output)))
 		}
 	}
 
-	return nil
+	return worktreePath, nil
 }
 
-func createWorktree(repoPath, branch string, config *Config) error {
+func createWorktree(repoPath, branch string, config *Config) (string, error) {
 	if err := validateBranchName(branch); err != nil {
-		return fmt.Errorf("invalid branch name: %w", err)
+		return "", fmt.Errorf("invalid branch name: %w", err)
 	}
 
 	worktreeDir, err := ensureWorktreeDir(repoPath, config)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Generate worktree path
@@ -1756,18 +1751,18 @@ func createWorktree(repoPath, branch string, config *Config) error {
 	default:
 		match, err := resolveRemoteBranchForSwitch(repoPath, branch)
 		if err != nil {
-			return err
+			return "", err
 		}
 		remoteMatch = match
 		if remoteMatch != nil {
 			if remoteMatch.needsFetch {
 				if err := fetchRemoteBranch(repoPath, remoteMatch.remote, branch); err != nil {
-					return err
+					return "", err
 				}
 			}
 			fullRef := fmt.Sprintf("refs/remotes/%s/%s", remoteMatch.remote, branch)
 			if !refExists(repoPath, fullRef) {
-				return fmt.Errorf("failed to resolve remote branch %s", remoteMatch.ref)
+				return "", fmt.Errorf("failed to resolve remote branch %s", remoteMatch.ref)
 			}
 			// Use --no-track and set upstream explicitly afterwards. `--track`
 			// rejects start points that aren't covered by the remote's
@@ -1781,7 +1776,7 @@ func createWorktree(repoPath, branch string, config *Config) error {
 
 	output, err := runGitCmdCombinedWithTimeout(repoPath, worktreeCmdTimeout, args...)
 	if err != nil {
-		return fmt.Errorf("failed to create worktree: %s", strings.TrimSpace(string(output)))
+		return "", fmt.Errorf("failed to create worktree: %s", strings.TrimSpace(string(output)))
 	}
 
 	// Point the new branch's upstream at the remote branch we used. Done by
@@ -1793,14 +1788,14 @@ func createWorktree(repoPath, branch string, config *Config) error {
 		mergeKey := fmt.Sprintf("branch.%s.merge", branch)
 		mergeRef := fmt.Sprintf("refs/heads/%s", branch)
 		if out, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "config", remoteKey, remoteMatch.remote); err != nil {
-			return fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
+			return "", fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
 		}
 		if out, err := runGitCmdCombinedWithTimeout(repoPath, gitCmdTimeout, "config", mergeKey, mergeRef); err != nil {
-			return fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
+			return "", fmt.Errorf("failed to set upstream for %s: %s", branch, strings.TrimSpace(string(out)))
 		}
 	}
 
-	return nil
+	return worktreePath, nil
 }
 
 func deleteWorktree(repoPath, worktreePath string) error {
@@ -2594,21 +2589,20 @@ func main() {
 			config = &Config{}
 		}
 
-		// Create the worktree
+		// Create the worktree.
+		var worktreePath string
 		if sourceBranch != "" {
 			fmt.Printf("Creating worktree '%s' from branch '%s'...\n", worktreeName, sourceBranch)
-			err = createWorktreeFromBranch(repoPath, worktreeName, sourceBranch, config)
+			worktreePath, err = createWorktreeFromBranch(repoPath, worktreeName, sourceBranch, config)
 		} else {
 			fmt.Printf("Creating worktree '%s'...\n", worktreeName)
-			err = createWorktree(repoPath, worktreeName, config)
+			worktreePath, err = createWorktree(repoPath, worktreeName, config)
 		}
 
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating worktree: %v\n", err)
 			os.Exit(1)
 		}
-
-		worktreePath := worktreePathForBranch(repoPath, worktreeName, config)
 
 		// Run post-create hook if configured
 		if err := runPostCreateHook(worktreePath, config); err != nil {

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -106,6 +106,66 @@ func TestGTRunFromLinkedWorktreeUsesMainRelativeWorktreeDir(t *testing.T) {
 	}
 }
 
+func TestGTRunFromSeparateGitDirUsesCheckoutRelativeWorktreeDir(t *testing.T) {
+	parentDir := t.TempDir()
+	repoPath := filepath.Join(parentDir, "checkout")
+	gitDir := filepath.Join(parentDir, "metadata", ".git")
+	if err := os.MkdirAll(filepath.Dir(gitDir), 0755); err != nil {
+		t.Fatalf("create metadata directory: %v", err)
+	}
+
+	runGit(t, parentDir, "init", "--separate-git-dir="+gitDir, "--initial-branch=master", repoPath)
+	readmePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("test"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoPath, "add", "README.md")
+	runGit(t, repoPath, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+
+	binaryPath := buildBinary(t)
+	cmd := exec.Command(binaryPath, "-x", "true", "feature-branch")
+	cmd.Dir = repoPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	worktreePath := filepath.Join(repoPath, defaultWorktreeDir, "feature-branch")
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("expected worktree to exist in checkout-relative path: %v", err)
+	}
+}
+
+func TestGTRunRejectsRepositoryRootWorktreeDir(t *testing.T) {
+	repoPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	configDir := filepath.Join(t.TempDir(), "gt")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("create config dir: %v", err)
+	}
+
+	configPath := filepath.Join(configDir, "config.json")
+	if err := os.WriteFile(configPath, []byte(`{"worktree_dir":"."}`), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cmd := exec.Command(binaryPath, "-x", "true", "feature-branch")
+	cmd.Dir = repoPath
+	cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+filepath.Dir(configDir))
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected gt to reject repository-root worktree directory, got success:\n%s", output)
+	}
+	if !strings.Contains(string(output), "worktree directory must not be the repository root") {
+		t.Fatalf("expected repository-root worktree directory error, got:\n%s", output)
+	}
+
+	branchOutput := runGit(t, repoPath, "branch", "--list", "feature-branch")
+	if strings.TrimSpace(string(branchOutput)) != "" {
+		t.Fatalf("expected feature branch not to be created, got %q", branchOutput)
+	}
+}
+
 func TestGTRunCreatesWorktreeFromRemoteBranch(t *testing.T) {
 	seedPath := initRepo(t)
 	binaryPath := buildBinary(t)

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -106,6 +106,50 @@ func TestGTRunFromLinkedWorktreeUsesMainRelativeWorktreeDir(t *testing.T) {
 	}
 }
 
+func TestGTRunPostCreateHookUsesCreatedWorktreePath(t *testing.T) {
+	repoPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	configHome := t.TempDir()
+	hookPathFile := filepath.Join(t.TempDir(), "hook-path")
+
+	configDir := filepath.Join(configHome, "gt")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatalf("create config directory: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.json")
+	configData := `{"shell":"/bin/sh","post_create":"pwd > \"$GT_HOOK_CWD\""}`
+	if err := os.WriteFile(configPath, []byte(configData), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	linkedWorktreePath := filepath.Join(repoPath, defaultWorktreeDir, "source")
+	runGit(t, repoPath, "worktree", "add", "-b", "source", linkedWorktreePath)
+
+	cmd := exec.Command(binaryPath, "-x", "true", "feature-branch")
+	cmd.Dir = linkedWorktreePath
+	cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+configHome, "GT_HOOK_CWD="+hookPathFile)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt run failed: %v\n%s", err, output)
+	}
+
+	hookPath, err := os.ReadFile(hookPathFile)
+	if err != nil {
+		t.Fatalf("read hook path: %v", err)
+	}
+	gotPath, err := filepath.EvalSymlinks(strings.TrimSpace(string(hookPath)))
+	if err != nil {
+		t.Fatalf("resolve hook path: %v", err)
+	}
+	wantPath, err := filepath.EvalSymlinks(filepath.Join(repoPath, defaultWorktreeDir, "feature-branch"))
+	if err != nil {
+		t.Fatalf("resolve expected worktree path: %v", err)
+	}
+	if string(gotPath) != wantPath {
+		t.Errorf("post-create hook ran in %q, want %q", gotPath, wantPath)
+	}
+}
+
 func TestGTRunFromSeparateGitDirUsesCheckoutRelativeWorktreeDir(t *testing.T) {
 	parentDir := t.TempDir()
 	repoPath := filepath.Join(parentDir, "checkout")

--- a/main_e2e_test.go
+++ b/main_e2e_test.go
@@ -61,6 +61,51 @@ func TestGTRunCreatesWorktreeAndUpdatesExcludes(t *testing.T) {
 	}
 }
 
+func TestGTRunFromLinkedWorktreeUsesMainRelativeWorktreeDir(t *testing.T) {
+	repoPath := initRepo(t)
+	binaryPath := buildBinary(t)
+	configHome := t.TempDir()
+
+	runGT := func(dir string, args ...string) []byte {
+		t.Helper()
+		cmd := exec.Command(binaryPath, args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(), "XDG_CONFIG_HOME="+configHome)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("gt %v failed from %s: %v\n%s", args, dir, err, output)
+		}
+		return output
+	}
+
+	runGT(repoPath, "-x", "true", "feature-one")
+
+	firstWorktreePath := filepath.Join(repoPath, defaultWorktreeDir, "feature-one")
+	featureFile := filepath.Join(firstWorktreePath, "from-feature-one.txt")
+	if err := os.WriteFile(featureFile, []byte("created on feature one"), 0644); err != nil {
+		t.Fatalf("write feature file: %v", err)
+	}
+	runGit(t, firstWorktreePath, "add", "from-feature-one.txt")
+	runGit(t, firstWorktreePath, "-c", "user.name=Test", "-c", "user.email=test@example.com",
+		"commit", "-m", "feature one commit")
+
+	runGT(firstWorktreePath, "-x", "true", "feature-two")
+
+	flatWorktreePath := filepath.Join(repoPath, defaultWorktreeDir, "feature-two")
+	if _, err := os.Stat(flatWorktreePath); err != nil {
+		t.Fatalf("expected worktree at main worktree-relative path: %v", err)
+	}
+
+	nestedWorktreePath := filepath.Join(firstWorktreePath, defaultWorktreeDir, "feature-two")
+	if _, err := os.Stat(nestedWorktreePath); err == nil {
+		t.Fatalf("did not expect nested worktree at %s", nestedWorktreePath)
+	}
+
+	if _, err := os.Stat(filepath.Join(flatWorktreePath, "from-feature-one.txt")); err != nil {
+		t.Fatalf("expected new worktree to branch from linked worktree HEAD: %v", err)
+	}
+}
+
 func TestGTRunCreatesWorktreeFromRemoteBranch(t *testing.T) {
 	seedPath := initRepo(t)
 	binaryPath := buildBinary(t)

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -39,6 +39,41 @@ func TestEnsureNoTrackedFilesPassesForEmptyDir(t *testing.T) {
 	}
 }
 
+func TestEnsureWorktreeDirRejectsRepositoryRoot(t *testing.T) {
+	repoPath := initRepo(t)
+
+	_, err := ensureWorktreeDir(repoPath, &Config{WorktreeDir: "."})
+	if err == nil {
+		t.Fatal("expected repository-root worktree directory to be rejected")
+	}
+}
+
+func TestResolveWorktreeDirFallsBackForSeparateGitDir(t *testing.T) {
+	parentDir := t.TempDir()
+	repoPath := filepath.Join(parentDir, "checkout")
+	gitDir := filepath.Join(parentDir, "metadata", ".git")
+	if err := os.MkdirAll(filepath.Dir(gitDir), 0755); err != nil {
+		t.Fatalf("create metadata directory: %v", err)
+	}
+
+	runGit(t, parentDir, "init", "--separate-git-dir="+gitDir, "--initial-branch=master", repoPath)
+	readmePath := filepath.Join(repoPath, "README.md")
+	if err := os.WriteFile(readmePath, []byte("test"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, repoPath, "add", "README.md")
+	runGit(t, repoPath, "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init")
+
+	worktreeDir, baseRepoPath := resolveWorktreeDir(repoPath, &Config{WorktreeDir: ".worktrees"})
+	if baseRepoPath != repoPath {
+		t.Errorf("base repository path = %q, want %q", baseRepoPath, repoPath)
+	}
+	wantWorktreeDir := filepath.Join(repoPath, ".worktrees")
+	if worktreeDir != wantWorktreeDir {
+		t.Errorf("worktree directory = %q, want %q", worktreeDir, wantWorktreeDir)
+	}
+}
+
 func TestGetAheadBehindWithContext(t *testing.T) {
 	repoPath := initRepo(t)
 	ctx := context.Background()

--- a/main_integration_test.go
+++ b/main_integration_test.go
@@ -74,6 +74,37 @@ func TestResolveWorktreeDirFallsBackForSeparateGitDir(t *testing.T) {
 	}
 }
 
+func TestResolveWorktreeDirFallsBackFromLinkedWorktreeWithSeparateGitDir(t *testing.T) {
+	parentDir := t.TempDir()
+	checkoutPath := filepath.Join(parentDir, "checkout")
+	gitDir := filepath.Join(parentDir, "metadata", ".git")
+	linkedWorktreePath := filepath.Join(parentDir, "linked")
+	if err := os.MkdirAll(filepath.Dir(gitDir), 0755); err != nil {
+		t.Fatalf("create metadata directory: %v", err)
+	}
+
+	runGit(t, parentDir, "init", "--separate-git-dir="+gitDir, "--initial-branch=master", checkoutPath)
+	runGit(t, checkoutPath, "-c", "user.name=Test", "-c", "user.email=test@example.com",
+		"commit", "--allow-empty", "-m", "init")
+	runGit(t, checkoutPath, "worktree", "add", "-b", "source", linkedWorktreePath)
+
+	worktreePath, err := createWorktree(linkedWorktreePath, "feature", &Config{})
+	if err != nil {
+		t.Fatalf("create worktree: %v", err)
+	}
+	wantWorktreePath := filepath.Join(linkedWorktreePath, defaultWorktreeDir, "feature")
+	if worktreePath != wantWorktreePath {
+		t.Errorf("worktree path = %q, want %q", worktreePath, wantWorktreePath)
+	}
+	if _, err := os.Stat(wantWorktreePath); err != nil {
+		t.Fatalf("expected linked-worktree-relative path to exist: %v", err)
+	}
+	metadataWorktreePath := filepath.Join(filepath.Dir(gitDir), defaultWorktreeDir, "feature")
+	if _, err := os.Stat(metadataWorktreePath); !os.IsNotExist(err) {
+		t.Fatalf("did not expect worktree under metadata directory: %v", err)
+	}
+}
+
 func TestGetAheadBehindWithContext(t *testing.T) {
 	repoPath := initRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Resolve relative worktree_dir values from the main worktree for normal non-bare repos with a real .git directory
- Fall back to the current Git top-level when that typical layout cannot be identified
- Keep branch creation based on the active worktree HEAD and add e2e coverage for linked-worktree launch behavior

## Tests
- go test ./...