### PR TITLE
fix: compact worktree branch spacing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.23.0
 require (
 	github.com/charmbracelet/bubbletea v1.3.6
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc
+	github.com/charmbracelet/x/ansi v0.9.3
 	github.com/cli/go-gh/v2 v2.12.2
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.9.3 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13 // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/cli/safeexec v1.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -35,7 +35,6 @@ const (
 	minViewportHeight    = 5
 	viewportPadding      = 8 // Lines for header/footer
 	hashDisplayLength    = 7
-	branchDisplayWidth   = 20
 	ellipsis             = "..."
 
 	// Git command timeouts
@@ -2704,20 +2703,17 @@ func (m model) View() string {
 				branchSuffix = shortFolderLabel + " │ " + statusAndPR + aheadBehind + " "
 			}
 
-			branchColumnWidth := max(branchDisplayWidth, lipgloss.Width(branchText))
 			if m.ui.width > 0 {
 				// Reserve the cursor, folder cue, and status symbols before sizing the
-				// branch column. These cues stay visible even for long branch names.
+				// branch label. These cues stay visible even for long branch names.
 				available := m.ui.width - lipgloss.Width(cursor) - lipgloss.Width(branchSuffix)
-				branchColumnWidth = max(1, min(branchColumnWidth, available))
+				branchText = truncateToWidth(branchText, max(1, available))
 			}
 
-			branchText = truncateToWidth(branchText, branchColumnWidth)
 			branch := branchStyle.Render(branchText)
 			if wt.IsCurrent {
 				branch = currentStyle.Render(branchText)
 			}
-			branch += strings.Repeat(" ", max(0, branchColumnWidth-lipgloss.Width(branchText)))
 
 			// Commit info
 			commitMsg := truncateString(wt.LastCommit.Message, maxCommitMsgLength)

--- a/main.go
+++ b/main.go
@@ -2703,12 +2703,14 @@ func (m model) View() string {
 				branchSuffix = shortFolderLabel + " │ " + statusAndPR + aheadBehind + " "
 			}
 
+			maxBranchWidth := lipgloss.Width(branchText)
 			if m.ui.width > 0 {
 				// Reserve the cursor, folder cue, and status symbols before sizing the
 				// branch label. These cues stay visible even for long branch names.
 				available := m.ui.width - lipgloss.Width(cursor) - lipgloss.Width(branchSuffix)
-				branchText = truncateToWidth(branchText, max(1, available))
+				maxBranchWidth = max(1, available)
 			}
+			branchText = truncateToWidth(branchText, maxBranchWidth)
 
 			branch := branchStyle.Render(branchText)
 			if wt.IsCurrent {

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -688,6 +688,23 @@ func TestWorktreeViewDoesNotTruncateBranchWhenThereIsRoom(t *testing.T) {
 	}
 }
 
+func TestWorktreeViewDoesNotTruncateBranchBeforeWindowSize(t *testing.T) {
+	branch := strings.Repeat("feature-", 8)
+	m := model{
+		wt: worktreeState{filtered: []Worktree{{
+			Branch:     branch,
+			Path:       "/repo",
+			LastCommit: CommitInfo{Message: "commit"},
+		}}},
+		repoPath:        "/repo",
+		mainWorktreeDir: "/repo",
+	}
+
+	if view := m.View(); !strings.Contains(view, branch) {
+		t.Fatalf("view truncated branch before receiving window size %q:\n%s", branch, view)
+	}
+}
+
 func TestFetchPullRequestStatesUsesPartialGraphQLData(t *testing.T) {
 	client := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
 		body := `{"data":{"repo0":{"pullRequests":{"nodes":[{"state":"OPEN","headRefOid":"abc123","headRepositoryOwner":{"login":"fishy"}}]},"parent":null},"repo1":null},"errors":[{"message":"repository not found"}]}`

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -593,6 +594,51 @@ func TestWorktreeViewPlacesPullRequestMarkerAfterBranch(t *testing.T) {
 	}
 }
 
+func TestWorktreeViewUsesCompactBranchSpacing(t *testing.T) {
+	tests := []struct {
+		name        string
+		branch      string
+		isCurrent   bool
+		branchLabel string
+	}{
+		{name: "current default branch", branch: "main", isCurrent: true, branchLabel: "● main"},
+		{name: "normal branch", branch: "fix", branchLabel: "fix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := model{
+				ui: uiState{width: 120, height: 20},
+				wt: worktreeState{filtered: []Worktree{{
+					Branch:     tt.branch,
+					Path:       "/repo",
+					IsCurrent:  tt.isCurrent,
+					LastCommit: CommitInfo{Message: "commit"},
+				}}},
+				repoPath:        "/repo",
+				mainWorktreeDir: "/repo",
+			}
+
+			line := worktreeDisplayLine(t, m.View(), tt.branchLabel)
+			wantPrefix := "▸ " + tt.branchLabel + " ✓ "
+			if !strings.HasPrefix(line, wantPrefix) {
+				t.Fatalf("worktree line = %q, want compact prefix %q", line, wantPrefix)
+			}
+		})
+	}
+}
+
+func worktreeDisplayLine(t *testing.T, view, branchLabel string) string {
+	t.Helper()
+	for _, line := range strings.Split(ansi.Strip(view), "\n") {
+		if strings.Contains(line, branchLabel) {
+			return line
+		}
+	}
+	t.Fatalf("expected branch label %q in view:\n%s", branchLabel, view)
+	return ""
+}
+
 func TestWorktreeViewKeepsPRMarkerVisibleForLongBranchAndPath(t *testing.T) {
 	branch := strings.Repeat("feature-", 12)
 	m := model{
@@ -611,11 +657,12 @@ func TestWorktreeViewKeepsPRMarkerVisibleForLongBranchAndPath(t *testing.T) {
 		if !strings.Contains(line, pullRequestSymbol) {
 			continue
 		}
-		if !strings.Contains(line, "[📂]") {
-			t.Fatalf("worktree line dropped folder mismatch marker:\n%s", line)
+		displayLine := ansi.Strip(line)
+		if !strings.Contains(displayLine, "... [📂] │ ✓ "+pullRequestSymbol) {
+			t.Fatalf("worktree line dropped truncation, folder, status, or PR syntax:\n%s", displayLine)
 		}
-		if lipgloss.Width(line) > m.ui.width {
-			t.Fatalf("worktree line width = %d, want at most %d:\n%s", lipgloss.Width(line), m.ui.width, line)
+		if lipgloss.Width(displayLine) > m.ui.width {
+			t.Fatalf("worktree line width = %d, want at most %d:\n%s", lipgloss.Width(displayLine), m.ui.width, displayLine)
 		}
 		return
 	}


### PR DESCRIPTION
## Summary

- remove the fixed-width branch column and its excess padding
- truncate branch labels only when the terminal width requires it
- preserve branch labels before the initial window-size event

## Testing

- go test ./...
- Codex review: no accepted or actionable findings