### PR TITLE
Speed up PR info loading

### DIFF
--- a/main.go
+++ b/main.go
@@ -136,7 +136,9 @@ type tokenResolver struct {
 	mu       sync.Mutex
 	getenv   func(string) string
 	fallback tokenLookupFunc
-	tokens   map[string]string
+	// gt is a short-lived TUI, and go-gh already caches file-backed auth for
+	// the process. Credential changes intentionally take effect on next launch.
+	tokens map[string]string
 }
 
 func newTokenResolver(getenv func(string) string, fallback tokenLookupFunc) *tokenResolver {
@@ -1640,6 +1642,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.wt.detailQueue = nil
 			m.wt.activeDetailFetches = 0
 			m.setErrorStatus(fmt.Sprintf("Load failed: %v", msg.err), statusMessageTimeout)
+			if pullRequestDiscoveryCmd := m.startPullRequestDiscovery(); pullRequestDiscoveryCmd != nil {
+				return m, tea.Batch(tickCmd(), pullRequestDiscoveryCmd)
+			}
 			return m, tickCmd()
 		}
 		previousStates := make(map[string]pullRequestState, len(m.wt.worktrees))

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -129,8 +130,54 @@ type pullRequestLookup struct {
 
 type tokenLookupFunc func(host string) (token, source string)
 
+var errGitHubTokenNotFound = errors.New("github token not found")
+
+type tokenResolver struct {
+	mu       sync.Mutex
+	getenv   func(string) string
+	fallback tokenLookupFunc
+	tokens   map[string]string
+}
+
+func newTokenResolver(getenv func(string) string, fallback tokenLookupFunc) *tokenResolver {
+	return &tokenResolver{
+		getenv:   getenv,
+		fallback: fallback,
+		tokens:   make(map[string]string),
+	}
+}
+
+func (r *tokenResolver) lookup(host string) (string, string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if token := r.tokens[host]; token != "" {
+		return token, "memory"
+	}
+	if r.getenv != nil {
+		if token := r.getenv("GH_TOKEN"); token != "" {
+			r.tokens[host] = token
+			return token, "GH_TOKEN"
+		}
+		if token := r.getenv("GITHUB_TOKEN"); token != "" {
+			r.tokens[host] = token
+			return token, "GITHUB_TOKEN"
+		}
+	}
+	if r.fallback == nil {
+		return "", ""
+	}
+	token, source := r.fallback(host)
+	if token != "" {
+		r.tokens[host] = token
+	}
+	return token, source
+}
+
+var processTokenResolver = newTokenResolver(os.Getenv, auth.TokenForHost)
+
 func defaultTokenLookup(host string) (string, string) {
-	return auth.TokenForHost(host)
+	return processTokenResolver.lookup(host)
 }
 
 // inputMode represents the current input state of the TUI.
@@ -183,6 +230,7 @@ type worktreeState struct {
 	prGeneration        int
 	prFetchAttempts     int
 	prLookups           []pullRequestLookup
+	prDiscoveryStarted  bool
 }
 
 // actionsState holds the state for the actions menu.
@@ -1127,6 +1175,14 @@ func (m *model) startDetailFetches() tea.Cmd {
 	return tea.Batch(cmds...)
 }
 
+func (m *model) startPullRequestDiscovery() tea.Cmd {
+	if m.wt.loading || m.wt.prDiscoveryStarted || len(m.wt.detailQueue) != 0 || m.wt.activeDetailFetches != 0 {
+		return nil
+	}
+	m.wt.prDiscoveryStarted = true
+	return discoverPullRequestLookupsCmd(m.repoPath, m.wt.worktrees, m.wt.prGeneration)
+}
+
 func (m *model) startPullRequestFetch() tea.Cmd {
 	if m.wt.prFetchAttempts >= maxPullRequestFetchAttempts {
 		return nil
@@ -1602,6 +1658,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.wt.detailGeneration++
 		m.wt.prGeneration++
 		m.wt.prFetchAttempts = 0
+		m.wt.prDiscoveryStarted = false
 		m.resetDetailQueue()
 		// Find current worktree path for tracking previous (session-only)
 		if m.wt.previousWorktree == "" {
@@ -1616,7 +1673,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if detailCmd := m.startDetailFetches(); detailCmd != nil {
 			cmds = append(cmds, detailCmd)
 		}
-		cmds = append(cmds, discoverPullRequestLookupsCmd(m.repoPath, m.wt.worktrees, m.wt.prGeneration))
+		if pullRequestDiscoveryCmd := m.startPullRequestDiscovery(); pullRequestDiscoveryCmd != nil {
+			cmds = append(cmds, pullRequestDiscoveryCmd)
+		}
 		return m, tea.Batch(cmds...)
 
 	case worktreeDetailLoadedMsg:
@@ -1629,6 +1688,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.applyWorktreeDetail(msg.detail)
 		if detailCmd := m.startDetailFetches(); detailCmd != nil {
 			return m, tea.Batch(tickCmd(), detailCmd)
+		}
+		if pullRequestDiscoveryCmd := m.startPullRequestDiscovery(); pullRequestDiscoveryCmd != nil {
+			return m, tea.Batch(tickCmd(), pullRequestDiscoveryCmd)
 		}
 		return m, tickCmd()
 
@@ -1653,6 +1715,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.applyPullRequestStates(msg.states)
 		if msg.err != nil {
+			if errors.Is(msg.err, errGitHubTokenNotFound) {
+				return m, tickCmd()
+			}
 			if retryCmd := m.startPullRequestFetch(); retryCmd != nil {
 				return m, tea.Batch(tickCmd(), retryCmd)
 			}
@@ -2223,7 +2288,7 @@ func loadPullRequestStatesForLookups(ctx context.Context, lookups []pullRequestL
 	}
 	token, _ := tokenLookup("github.com")
 	if token == "" {
-		return nil, errors.New("github token not found")
+		return nil, errGitHubTokenNotFound
 	}
 
 	return fetchPullRequestStates(ctx, client, githubGraphQLEndpoint, token, lookups)

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -421,13 +421,65 @@ func TestLoadPullRequestStatesUsesProvidedTokenLookupWithoutGHBinary(t *testing.
 	}
 }
 
-func TestDefaultTokenLookupPrefersEnvironment(t *testing.T) {
-	t.Setenv("GH_TOKEN", "token-from-env")
-	t.Setenv("GITHUB_TOKEN", "")
+func TestTokenResolverUsesEnvironmentFastPath(t *testing.T) {
+	tests := []struct {
+		name   string
+		env    map[string]string
+		want   string
+		source string
+	}{
+		{
+			name:   "GH_TOKEN takes precedence",
+			env:    map[string]string{"GH_TOKEN": "gh-token", "GITHUB_TOKEN": "github-token"},
+			want:   "gh-token",
+			source: "GH_TOKEN",
+		},
+		{
+			name:   "GITHUB_TOKEN is the second choice",
+			env:    map[string]string{"GITHUB_TOKEN": "github-token"},
+			want:   "github-token",
+			source: "GITHUB_TOKEN",
+		},
+	}
 
-	token, _ := defaultTokenLookup("github.com")
-	if token != "token-from-env" {
-		t.Fatalf("token = %q, want GH_TOKEN value", token)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fallbackCalls := 0
+			resolver := newTokenResolver(func(name string) string {
+				return tt.env[name]
+			}, func(string) (string, string) {
+				fallbackCalls++
+				return "fallback-token", "fallback"
+			})
+
+			token, source := resolver.lookup("github.com")
+			if token != tt.want || source != tt.source {
+				t.Fatal("resolver did not use the expected environment variable")
+			}
+			if fallbackCalls != 0 {
+				t.Fatalf("fallback calls = %d, want 0", fallbackCalls)
+			}
+		})
+	}
+}
+
+func TestTokenResolverReusesSuccessfulLookupInMemory(t *testing.T) {
+	fallbackCalls := 0
+	resolver := newTokenResolver(func(string) string { return "" }, func(string) (string, string) {
+		fallbackCalls++
+		return "resolved-token", "fallback"
+	})
+
+	first, firstSource := resolver.lookup("github.com")
+	second, secondSource := resolver.lookup("github.com")
+	if first != "resolved-token" || firstSource != "fallback" {
+		t.Fatal("first lookup did not use the fallback token")
+	}
+	if second != first || secondSource != "memory" {
+		t.Fatal("second lookup did not reuse the in-memory token")
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("fallback calls = %d, want 1", fallbackCalls)
 	}
 }
 
@@ -484,6 +536,77 @@ func TestWorktreesLoadedRebuildsFilteredAndPreservesPullRequestState(t *testing.
 	}
 }
 
+func TestPullRequestDiscoveryWaitsForWorktreeDetails(t *testing.T) {
+	worktrees := make([]Worktree, maxDetailFetchWorkers+1)
+	for i := range worktrees {
+		worktrees[i] = Worktree{Branch: fmt.Sprintf("branch-%d", i)}
+	}
+	m := model{repoPath: "/repo"}
+
+	updated, _ := m.Update(worktreesLoadedMsg{worktrees: worktrees})
+	m = updated.(model)
+	if m.wt.prDiscoveryStarted {
+		t.Fatal("PR discovery started while initial detail fetches were active")
+	}
+	generation := m.wt.detailGeneration
+
+	updated, _ = m.Update(worktreeDetailLoadedMsg{detail: worktreeDetails{index: 0}, generation: generation - 1})
+	m = updated.(model)
+	if m.wt.prDiscoveryStarted {
+		t.Fatal("stale detail message started PR discovery")
+	}
+
+	for i := range worktrees {
+		updated, _ = m.Update(worktreeDetailLoadedMsg{detail: worktreeDetails{index: i}, generation: generation})
+		m = updated.(model)
+		if i < len(worktrees)-1 && m.wt.prDiscoveryStarted {
+			t.Fatalf("PR discovery started after %d of %d details", i+1, len(worktrees))
+		}
+	}
+	if !m.wt.prDiscoveryStarted {
+		t.Fatal("PR discovery did not start when the detail queue drained")
+	}
+
+	updated, _ = m.Update(worktreesLoadedMsg{worktrees: []Worktree{{Branch: "refreshed"}}})
+	m = updated.(model)
+	if m.wt.prDiscoveryStarted {
+		t.Fatal("refresh did not defer PR discovery for the new detail generation")
+	}
+}
+
+func TestPullRequestDiscoveryStartsWithZeroWorktrees(t *testing.T) {
+	m := model{repoPath: "/repo"}
+
+	updated, _ := m.Update(worktreesLoadedMsg{})
+	m = updated.(model)
+	if !m.wt.prDiscoveryStarted {
+		t.Fatal("PR discovery did not start for an empty worktree list")
+	}
+}
+
+func TestPullRequestDiscoveryDoesNotStartDuringRefresh(t *testing.T) {
+	m := model{
+		repoPath: "/repo",
+		wt: worktreeState{
+			worktrees:        []Worktree{{Branch: "feature"}},
+			detailGeneration: 1,
+		},
+	}
+	m.refreshWorktrees()
+
+	updated, _ := m.Update(worktreeDetailLoadedMsg{detail: worktreeDetails{index: 0}, generation: 1})
+	m = updated.(model)
+	if m.wt.prDiscoveryStarted {
+		t.Fatal("detail completion from the prior generation started PR discovery during refresh")
+	}
+
+	updated, _ = m.Update(worktreesLoadedMsg{})
+	m = updated.(model)
+	if !m.wt.prDiscoveryStarted {
+		t.Fatal("PR discovery did not restart after refresh completed")
+	}
+}
+
 func TestPullRequestFetchRetriesOnlyOnce(t *testing.T) {
 	m := model{
 		repoPath: "/repo",
@@ -509,6 +632,23 @@ func TestPullRequestFetchRetriesOnlyOnce(t *testing.T) {
 	m = updated.(model)
 	if got := m.wt.prFetchAttempts; got != 2 {
 		t.Fatalf("attempts after second failure = %d, want no third attempt", got)
+	}
+}
+
+func TestPullRequestFetchDoesNotRetryMissingCredentials(t *testing.T) {
+	m := model{
+		wt: worktreeState{
+			prGeneration:    1,
+			prFetchAttempts: 1,
+			prLookups:       []pullRequestLookup{{Branch: "feature"}},
+			worktrees:       []Worktree{{Branch: "feature", PRState: pullRequestStatePending}},
+		},
+	}
+
+	updated, _ := m.Update(pullRequestsLoadedMsg{generation: 1, err: errGitHubTokenNotFound})
+	m = updated.(model)
+	if m.wt.prFetchAttempts != 1 {
+		t.Fatalf("fetch attempts = %d, want no retry", m.wt.prFetchAttempts)
 	}
 }
 

--- a/main_unit_test.go
+++ b/main_unit_test.go
@@ -607,6 +607,32 @@ func TestPullRequestDiscoveryDoesNotStartDuringRefresh(t *testing.T) {
 	}
 }
 
+func TestPullRequestDiscoveryStartsAfterFailedRefresh(t *testing.T) {
+	m := model{
+		repoPath: "/repo",
+		wt: worktreeState{
+			worktrees:        []Worktree{{Branch: "feature"}},
+			detailGeneration: 1,
+		},
+	}
+	m.refreshWorktrees()
+
+	updated, _ := m.Update(worktreeDetailLoadedMsg{detail: worktreeDetails{index: 0}, generation: 1})
+	m = updated.(model)
+	if m.wt.prDiscoveryStarted {
+		t.Fatal("detail completion started PR discovery while refresh was pending")
+	}
+
+	updated, cmd := m.Update(worktreesLoadedMsg{err: fmt.Errorf("refresh failed")})
+	m = updated.(model)
+	if !m.wt.prDiscoveryStarted {
+		t.Fatal("failed refresh left PR discovery unstarted")
+	}
+	if cmd == nil {
+		t.Fatal("failed refresh did not schedule PR discovery")
+	}
+}
+
 func TestPullRequestFetchRetriesOnlyOnce(t *testing.T) {
 	m := model{
 		repoPath: "/repo",


### PR DESCRIPTION
## Summary

- defer PR discovery until worktree detail loading completes so startup rendering stays responsive
- use environment tokens as a fast path and cache successful auth lookups for the TUI process
- avoid retrying when credentials are absent and resume deferred discovery after a failed refresh

## Testing

- go test ./...
- go test -race ./...
- go vet ./...
- Codex branch review: clean, no accepted or actionable findings